### PR TITLE
fix: game_started event never fires

### DIFF
--- a/client/src/hooks/actions.ts
+++ b/client/src/hooks/actions.ts
@@ -311,36 +311,6 @@ export const useActions = () => {
     [isPracticeMode, practiceGame, setGame, account, chain.id, capture, mode],
   );
 
-  const start = useCallback(
-    async (gameId: number, game: any) => {
-      if (isPracticeMode) {
-        if (!practiceGame) return false;
-        try {
-          const rand = new Random(BigInt(Math.floor(Math.random() * 1000000)));
-          GameEngine.start(practiceGame, rand);
-          setGame(practiceGame.clone());
-          capture("game_started", { game_id: gameId, mode });
-          return true;
-        } catch (e) {
-          console.error(e);
-          return false;
-        }
-      }
-
-      try {
-        if (!game) return false;
-        const rand = new Random(BigInt(gameId));
-        GameEngine.start(game, rand);
-        capture("game_started", { game_id: gameId, mode });
-        return true;
-      } catch (e) {
-        console.log({ e });
-        return false;
-      }
-    },
-    [isPracticeMode, practiceGame, setGame, capture, mode],
-  );
-
   const questClaims = useCallback(
     async (
       params: { playerAddress: string; questId: string; intervalId: number }[],
@@ -592,7 +562,6 @@ export const useActions = () => {
 
   return {
     isPracticeMode,
-    start,
     set,
     select,
     apply,

--- a/client/src/pages/game.tsx
+++ b/client/src/pages/game.tsx
@@ -41,6 +41,7 @@ export const Game = () => {
   const { isPracticeMode, set, select, apply, claim } = useActions();
   const { capture } = usePostHog();
   const gameOverFiredRef = useRef<number | null>(null);
+  const gameStartedFiredRef = useRef<number | null>(null);
 
   const { game: practiceGame, start: startPractice } = usePractice();
   const { supply: currentSupply, username } = useHeader();
@@ -121,6 +122,22 @@ export const Game = () => {
       practiceInitializedRef.current = true;
     }
   }, [isPracticeMode, practiceGame, currentSupply, startPractice, multiplier]);
+
+  // Track game_started when a game first becomes available
+  useEffect(() => {
+    if (!game || game.over) return;
+    if (gameStartedFiredRef.current !== game.id) {
+      capture("game_started", {
+        game_id: game.id,
+        mode: isPracticeMode
+          ? window.location.pathname === "/tutorial"
+            ? "tutorial"
+            : "practice"
+          : "real",
+      });
+      gameStartedFiredRef.current = game.id;
+    }
+  }, [game, isPracticeMode, capture]);
 
   // Reset loading states when game model changes (transaction succeeded and data updated)
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fixes `game_started` PostHog event which has **zero recorded events** despite active gameplay (1,613 `game_over` events in the last 30 days)
- Removes dead `start()` function from `useActions` hook that was never called
- Adds `game_started` tracking in `game.tsx` where games actually load, using a ref for deduplication (same pattern as `gameOverFiredRef`)

## Rationale
The `game_started` capture was inside `actions.start()` which was never called from any component:
- Practice/tutorial games start via `PracticeProvider.start()` 
- Real games start on-chain via purchase transactions

This broke the "Games Started per Day" insight and the "Game Completion Funnel" on the Core Game Loop dashboard, both of which depend on this event.

## Test plan
- [x] All 102 tests pass
- [x] Format, lint, and type checks pass
- [x] Build succeeds
- [ ] After deploy, verify `game_started` events appear in PostHog project 155748
- [ ] Verify "Games Started per Day" dashboard tile populates
- [ ] Verify "Game Completion Funnel" shows data for the first step

🤖 Generated with [Claude Code](https://claude.com/claude-code)