### PR TITLE
feat: add render-daily-replay skill for remotion auto-render

### DIFF
--- a/.agents/skills/render-daily-replay/SKILL.md
+++ b/.agents/skills/render-daily-replay/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: render-daily-replay
+description: Auto-render a Remotion video replay of a Nums game on Mainnet. Resolves the target `gameId` from Torii (best reward of the day OR best score of the day, OR a specific gameId the user provides), silently auto-fetches the current NUMS price from Ekubo, then runs `pnpm remotion:render:game` with the right props. Use when the user asks to render today's top game, the daily winner, the biggest reward, the highest score, or any specific gameId, without having to assemble the render command by hand.
+metadata:
+  tags: nums, remotion, replay, daily, torii, mainnet, ekubo, render, video, automation
+---
+
+## When to use
+
+Load this skill when the user asks for things like:
+
+- "Render the best reward of today"
+- "Make a video of today's top scorer"
+- "Render the daily winner"
+- "Render game 1523"
+- "Render today's highest score as a replay"
+- Any request that maps to the shape `pnpm remotion:render:game '{"gameId":N,"numsPrice":P}'`
+
+For how the Remotion package is wired internally (webpack, overrides, fonts, hosting), also load **`nums-remotion-replay`**. This skill is about **calling** the render command; that one is about **editing** the render code.
+
+## Core principle
+
+Every happy path through this skill ends with exactly one command:
+
+```bash
+pnpm remotion:render:game '{"gameId":<N>,"numsPrice":<P>}'
+```
+
+run from the repo root. Everything else in this skill is about resolving `<N>` and `<P>` with zero user guesswork.
+
+- `<N>` comes from Torii (one of two stored SQL queries) or from the user directly.
+- `<P>` is always fetched silently from Ekubo — the same source the client app uses. Never hardcode it, never ask the user.
+
+## Endpoints (Mainnet only)
+
+### Torii SQL — from `client/.env.production`
+
+```
+VITE_SN_MAIN_TORII_URL = "https://api.cartridge.gg/x/nums-mainnet/torii"
+```
+
+SQL endpoint = `${VITE_SN_MAIN_TORII_URL}/sql` →
+`https://api.cartridge.gg/x/nums-mainnet/torii/sql`
+
+Queries are sent as `GET` with `?query=...` or `POST` with the SQL in the body. The helper script uses `curl -G --data-urlencode` to handle escaping.
+
+### Ekubo quoter — same API the client uses
+
+```
+https://prod-api-quoter.ekubo.org/{chainId}/{amount}/{tokenHex}/{quoteHex}
+```
+
+Mainnet constants (verified against `client/src/context/prices.tsx` and `client/src/config.ts`):
+
+| Field               | Value                                                                                                                |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `chainId` (SN_MAIN) | `23448594291968334` (decimal form of `shortString("SN_MAIN")`)                                                       |
+| `amount`            | `100000000000000000000` (100 NUMS, 18 decimals)                                                                      |
+| NUMS token          | `0x2e82800f97afded96e8e88f9788f2d8f097edb04c9e9b920ceb1ec11f265158` (from `manifest_mainnet.json` → `NUMS-Token`)    |
+| Quote (USDC)        | `0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb` (from `.env.production` → `VITE_SN_MAIN_QUOTE`) |
+
+Formula (mirrors `fetchTokenUsdPrice` in `client/src/context/prices.tsx`):
+
+```
+numsPrice = total_calculated / 1e6 / 100
+```
+
+- `total_calculated` = Ekubo response field, USDC amount (6 decimals) received for swapping 100 NUMS → USDC
+- `/ 1e6` → undo USDC decimals
+- `/ 100` → divide by the 100 NUMS input, giving USD per 1 NUMS
+
+## The two stored SQL queries
+
+### Query A — Best reward of today (most NUMS won)
+
+```sql
+SELECT
+    c.username,
+    g.game_id,
+    g.player_id AS player,
+    ('0x' || LTRIM(SUBSTR(g.reward, 3), '0') ->> '$') AS reward_decimal,
+    g.internal_executed_at
+FROM "NUMS-Claimed" AS g
+JOIN controllers AS c ON c.address = g.player_id
+WHERE DATE(g.internal_executed_at) = DATE('now')
+ORDER BY reward_decimal DESC
+LIMIT 1;
+```
+
+Returns a single row with:
+
+- `game_id` — hex string, e.g. `0x00000000000005f3` (→ `1523`)
+- `username` — controller username of the winner
+- `player` — player address
+- `reward_decimal` — reward already decoded to a decimal integer (NUMS, whole units)
+- `internal_executed_at` — timestamp
+
+### Query B — Best score of today (highest placed numbers)
+
+```sql
+SELECT
+    g.game_id,
+    g.score
+FROM "NUMS-LeaderboardScore" AS g
+WHERE DATE(g.internal_executed_at) = DATE('now')
+ORDER BY score DESC
+LIMIT 1;
+```
+
+Returns a single row with:
+
+- `game_id` — hex string, padded to 64 hex chars (same underlying value, different padding from Query A)
+- `score` — hex string (e.g. `0x0000000000000012` = `18`)
+
+Both `game_id` outputs must be converted to a decimal integer before being passed to the render command.
+
+## Workflow
+
+### Step 0 — Parse the user's request
+
+Look for these signals in the user's message:
+
+| User says                                              | Mode          | Action                  |
+| ------------------------------------------------------ | ------------- | ----------------------- |
+| "best reward", "top reward", "biggest prize", "winner" | `best-reward` | Run Query A             |
+| "best score", "top score", "highest score", "top 1"    | `best-score`  | Run Query B             |
+| "game 1523", "gameId 1523", a bare number              | `game-id`     | Use the number directly |
+| Ambiguous ("render today's game", "make a replay")     | ask once      | See Step 1              |
+
+### Step 1 — Clarify only if ambiguous
+
+If the user did not specify, ask **one** question:
+
+> Which game should I render?
+>
+> 1. **Best reward** of today
+> 2. **Best score** of today
+> 3. A specific gameId (please provide the decimal number)
+
+Do **not** ask about `numsPrice` — it is always auto-fetched.
+
+### Step 2 — Resolve `gameId`
+
+Run the helper script with the appropriate flag. It handles Torii, hex→decimal conversion, and empty-result handling in one place:
+
+```bash
+./.agents/skills/render-daily-replay/scripts/render-daily-replay.sh --best-reward
+./.agents/skills/render-daily-replay/scripts/render-daily-replay.sh --best-score
+./.agents/skills/render-daily-replay/scripts/render-daily-replay.sh --game-id 1523
+```
+
+The script:
+
+1. Fetches the Torii row (for `--best-reward` / `--best-score`) and extracts `game_id`.
+2. Converts hex → decimal.
+3. Fetches `numsPrice` from Ekubo and computes `total_calculated / 1e6 / 100`.
+4. Echoes a summary block (game id, username/score if applicable, numsPrice).
+5. Invokes `pnpm remotion:render:game '{"gameId":N,"numsPrice":P}'`.
+6. Verifies `remotion/out/game-replay.mp4` exists.
+
+Flags:
+
+- `--best-reward` — use Query A
+- `--best-score` — use Query B
+- `--game-id N` — use `N` directly (skip Torii fetch)
+- `--dry-run` — print the final command and exit without rendering (use this during smoke-tests or when the user wants a preview)
+- `--nums-price X` — override the auto-fetched price (escape hatch; do not offer proactively)
+
+### Step 3 — Announce and execute
+
+Before running the script, tell the user:
+
+- Which mode you're using (best-reward / best-score / specific gameId)
+- The resolved `gameId` (decimal)
+- The auto-fetched `numsPrice`
+- The fact that rendering takes 2–5 minutes
+
+Then run the script (without `--dry-run`) and stream its output. The final `.mp4` lands at `remotion/out/game-replay.mp4`.
+
+### Step 4 — Confirm output
+
+After the script exits cleanly:
+
+```bash
+ls -lh remotion/out/game-replay.mp4
+```
+
+Report the absolute path and file size to the user.
+
+## Non-obvious gotchas
+
+1. **Torii URL lives in `client/.env.production`**, not at repo root. Key is `VITE_SN_MAIN_TORII_URL`, and SQL is served at `${URL}/sql`. Do not hardcode a different host; the value in `remotion/src/data/torii.ts` uses a legacy alias (`nums-main`) that happens to resolve to the same instance, but this skill is authoritative on the mainnet URL.
+
+2. **`game_id` is hex-encoded in both queries, with different padding.** Query A pads to 16 hex chars (`0x00000000000005f3`), Query B pads to 64 (`0x00000000...000005f3`). Both must be parsed as `int(hex, 16)` before being embedded in the render props. The helper script does this with `python3`.
+
+3. **`numsPrice` is a JSON number, not a string.** `'{"numsPrice":0.012}'` is correct; `'{"numsPrice":"0.012"}'` will crash Zod validation in `remotion/src/root.tsx`. When printing the final JSON, use `printf '%s' "$json"` rather than `echo` to avoid surprises with special chars.
+
+4. **Render command must run from repo root**, not from `remotion/`. The root `package.json` wrapper handles the `cd remotion` internally. The helper script enforces this with `cd "$(git rev-parse --show-toplevel)"`.
+
+5. **Ekubo silent failures.** If Ekubo returns `{"error":"..."}` or `total_calculated` is missing, the script must abort with a clear message — do **not** fall back to the default `0.01138` from `remotion/src/root.tsx`, and do **not** ask the user to guess. A stale price on the video is a worse outcome than a failed render.
+
+6. **Empty Torii result.** If today has no claimed rewards (Query A empty) or no leaderboard entries (Query B empty), abort with a clear message. Offer to fall back to the other query or to a user-supplied `gameId`. Never pass `null`/`undefined` to the render command.
+
+7. **`reward_decimal` is already decoded to whole NUMS**, thanks to the SQLite JSON trick in the query. Display it as-is (e.g. `16606 NUMS`), do **not** divide by `10^18`.
+
+8. **`score` in Query B is hex.** Convert it to decimal before showing it to the user. `0x0000000000000012` = `18` placed numbers.
+
+9. **The render command blocks.** It takes 2–5 minutes depending on `snapshots.length`. Do **not** background it — the user needs to see the output, and failures should propagate. If Claude runs this via a tool call, pass a generous timeout (e.g. 10 min).
+
+10. **Video dimensions must stay even.** This is the concern of `nums-remotion-replay`, not this skill, but be aware: if the render fails with an H264 error, load that skill.
+
+## Example conversation shapes
+
+```
+User: "Render today's biggest prize game as a replay."
+Claude:
+  - Parses: best-reward intent, no gameId override, no numsPrice override.
+  - Runs: ./.agents/skills/render-daily-replay/scripts/render-daily-replay.sh --best-reward
+  - Reports resolved gameId, username, reward, numsPrice, then output path.
+```
+
+```
+User: "Render game 1523 for me."
+Claude:
+  - Parses: game-id=1523.
+  - Runs: ./.agents/skills/render-daily-replay/scripts/render-daily-replay.sh --game-id 1523
+  - Reports gameId, numsPrice, output path.
+```
+
+```
+User: "Make a replay of today's top score."
+Claude:
+  - Parses: best-score intent.
+  - Runs: ./.agents/skills/render-daily-replay/scripts/render-daily-replay.sh --best-score
+  - Reports gameId, score (decimal), numsPrice, output path.
+```
+
+```
+User: "Render today's game." (ambiguous)
+Claude:
+  - Asks: best reward or best score?
+  - Waits for answer, then proceeds as above.
+```
+
+## Related skills
+
+- **`nums-remotion-replay`** — how the `remotion/` package is wired (webpack, overrides, fonts, hosting, `calculateMetadata`). Load this if rendering fails with a code-level error.
+- **`remotion-best-practices`** — generic Remotion patterns.
+- **`dojo-indexer`** — Torii SQL endpoint structure and how Dojo models are indexed.

--- a/.agents/skills/render-daily-replay/scripts/render-daily-replay.sh
+++ b/.agents/skills/render-daily-replay/scripts/render-daily-replay.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TORII_SQL_URL="https://api.cartridge.gg/x/nums-mainnet/torii/sql"
+
+EKUBO_CHAIN_ID="23448594291968334"
+NUMS_TOKEN="0x2e82800f97afded96e8e88f9788f2d8f097edb04c9e9b920ceb1ec11f265158"
+QUOTE_TOKEN="0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb"
+EKUBO_AMOUNT="100000000000000000000"
+EKUBO_URL="https://prod-api-quoter.ekubo.org/${EKUBO_CHAIN_ID}/${EKUBO_AMOUNT}/${NUMS_TOKEN}/${QUOTE_TOKEN}"
+
+# Source-of-truth references (verify before editing any constant above):
+#   TORII_SQL_URL   = client/.env.production → VITE_SN_MAIN_TORII_URL + "/sql"
+#   EKUBO_CHAIN_ID  = decimal of shortString.encodeShortString("SN_MAIN")
+#   NUMS_TOKEN      = manifest_mainnet.json → NUMS-Token.address
+#   QUOTE_TOKEN     = client/.env.production → VITE_SN_MAIN_QUOTE
+#   EKUBO_AMOUNT    = 100 * 10^18 (100 NUMS scaled by token decimals)
+
+# shellcheck disable=SC2016
+QUERY_BEST_REWARD='SELECT
+    c.username,
+    g.game_id,
+    g.player_id AS player,
+    ('"'"'0x'"'"' || LTRIM(SUBSTR(g.reward, 3), '"'"'0'"'"') ->> '"'"'$'"'"') AS reward_decimal,
+    g.internal_executed_at
+FROM "NUMS-Claimed" AS g
+JOIN controllers AS c ON c.address = g.player_id
+WHERE DATE(g.internal_executed_at) = DATE('"'"'now'"'"')
+ORDER BY reward_decimal DESC
+LIMIT 1;'
+
+QUERY_BEST_SCORE='SELECT
+    g.game_id,
+    g.score
+FROM "NUMS-LeaderboardScore" AS g
+WHERE DATE(g.internal_executed_at) = DATE('"'"'now'"'"')
+ORDER BY score DESC
+LIMIT 1;'
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+hex_to_decimal() {
+  local hex="$1"
+  [[ -z "$hex" || "$hex" == "null" ]] && die "hex_to_decimal: empty input"
+  python3 -c "import sys; print(int('$hex', 16))"
+}
+
+usage() {
+  cat <<'USAGE'
+render-daily-replay.sh — resolve gameId + numsPrice and invoke the render
+
+Usage:
+  render-daily-replay.sh --best-reward               today's top reward via Torii
+  render-daily-replay.sh --best-score                today's top score via Torii
+  render-daily-replay.sh --game-id <N>               render a specific gameId
+  render-daily-replay.sh <any-mode> --dry-run        print the final command, don't render
+  render-daily-replay.sh <any-mode> --nums-price <P> override auto-fetched price
+
+Exactly one of --best-reward / --best-score / --game-id is required.
+USAGE
+}
+
+MODE=""
+GAME_ID_OVERRIDE=""
+NUMS_PRICE_OVERRIDE=""
+DRY_RUN="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --best-reward)
+      [[ -n "$MODE" ]] && die "cannot combine --best-reward with --$MODE"
+      MODE="best-reward"
+      shift
+      ;;
+    --best-score)
+      [[ -n "$MODE" ]] && die "cannot combine --best-score with --$MODE"
+      MODE="best-score"
+      shift
+      ;;
+    --game-id)
+      [[ -n "$MODE" ]] && die "cannot combine --game-id with --$MODE"
+      MODE="game-id"
+      [[ $# -ge 2 ]] || die "--game-id requires a value"
+      GAME_ID_OVERRIDE="$2"
+      shift 2
+      ;;
+    --nums-price)
+      [[ $# -ge 2 ]] || die "--nums-price requires a value"
+      NUMS_PRICE_OVERRIDE="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -z "$MODE" ]] && {
+  usage >&2
+  die "one of --best-reward / --best-score / --game-id is required"
+}
+
+require_cmd curl
+require_cmd jq
+require_cmd python3
+require_cmd pnpm
+require_cmd git
+
+# Must run from repo root: the `pnpm remotion:render:game` wrapper already
+# handles `cd remotion` internally, so chdir into `remotion/` here would
+# break workspace resolution.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+GAME_ID=""
+SUMMARY_LABEL=""
+
+case "$MODE" in
+  best-reward)
+    echo "→ fetching today's best reward from Torii…"
+    RESPONSE="$(curl -sSfG "$TORII_SQL_URL" --data-urlencode "query=$QUERY_BEST_REWARD")"
+    COUNT="$(echo "$RESPONSE" | jq 'length')"
+    [[ "$COUNT" -eq 0 ]] && die "no claimed rewards found for today; try --best-score or --game-id"
+
+    GAME_ID_HEX="$(echo "$RESPONSE" | jq -r '.[0].game_id')"
+    USERNAME="$(echo "$RESPONSE" | jq -r '.[0].username')"
+    REWARD="$(echo "$RESPONSE" | jq -r '.[0].reward_decimal')"
+    EXEC_AT="$(echo "$RESPONSE" | jq -r '.[0].internal_executed_at')"
+    GAME_ID="$(hex_to_decimal "$GAME_ID_HEX")"
+    SUMMARY_LABEL="best reward — ${USERNAME} won ${REWARD} NUMS (game ${GAME_ID}) at ${EXEC_AT}"
+    ;;
+  best-score)
+    echo "→ fetching today's best score from Torii…"
+    RESPONSE="$(curl -sSfG "$TORII_SQL_URL" --data-urlencode "query=$QUERY_BEST_SCORE")"
+    COUNT="$(echo "$RESPONSE" | jq 'length')"
+    [[ "$COUNT" -eq 0 ]] && die "no leaderboard scores found for today; try --best-reward or --game-id"
+
+    GAME_ID_HEX="$(echo "$RESPONSE" | jq -r '.[0].game_id')"
+    SCORE_HEX="$(echo "$RESPONSE" | jq -r '.[0].score')"
+    GAME_ID="$(hex_to_decimal "$GAME_ID_HEX")"
+    SCORE="$(hex_to_decimal "$SCORE_HEX")"
+    SUMMARY_LABEL="best score — game ${GAME_ID} with ${SCORE} placed numbers"
+    ;;
+  game-id)
+    [[ "$GAME_ID_OVERRIDE" =~ ^[0-9]+$ ]] || die "--game-id must be a decimal integer, got: $GAME_ID_OVERRIDE"
+    GAME_ID="$GAME_ID_OVERRIDE"
+    SUMMARY_LABEL="user-specified game ${GAME_ID}"
+    ;;
+esac
+
+NUMS_PRICE=""
+if [[ -n "$NUMS_PRICE_OVERRIDE" ]]; then
+  [[ "$NUMS_PRICE_OVERRIDE" =~ ^[0-9]+(\.[0-9]+)?$ ]] || die "--nums-price must be a decimal number, got: $NUMS_PRICE_OVERRIDE"
+  NUMS_PRICE="$NUMS_PRICE_OVERRIDE"
+  echo "→ numsPrice: ${NUMS_PRICE} (user override)"
+else
+  echo "→ fetching current NUMS price from Ekubo…"
+  EKUBO_RESPONSE="$(curl -sSf "$EKUBO_URL")" || die "Ekubo request failed"
+
+  # Abort on explicit error payloads or missing field. A stale/guessed price
+  # would silently produce a misleading video, which is a worse outcome than
+  # a loud failure. Never fall back to the default 0.01138 from root.tsx.
+  if echo "$EKUBO_RESPONSE" | jq -e 'has("error")' >/dev/null 2>&1; then
+    ERR_MSG="$(echo "$EKUBO_RESPONSE" | jq -r '.error')"
+    die "Ekubo returned error: $ERR_MSG"
+  fi
+
+  TOTAL_CALCULATED="$(echo "$EKUBO_RESPONSE" | jq -r '.total_calculated // empty')"
+  [[ -z "$TOTAL_CALCULATED" ]] && die "Ekubo response missing total_calculated: $EKUBO_RESPONSE"
+
+  # Formula mirrors client/src/context/prices.tsx → fetchTokenUsdPrice():
+  #   numsPrice = total_calculated / 1e6 / 100
+  # where /1e6 undoes USDC 6-decimal scaling and /100 normalizes the 100 NUMS input.
+  NUMS_PRICE="$(python3 -c "print(round(int('$TOTAL_CALCULATED') / 1e6 / 100, 8))")"
+  echo "→ numsPrice: ${NUMS_PRICE} (auto-fetched)"
+fi
+
+PROPS_JSON="$(jq -n --argjson gameId "$GAME_ID" --argjson numsPrice "$NUMS_PRICE" \
+  '{gameId: $gameId, numsPrice: $numsPrice}' --compact-output)"
+
+echo ""
+echo "───────────────────────────────────────────────"
+echo " mode:       $MODE"
+echo " summary:    $SUMMARY_LABEL"
+echo " gameId:     $GAME_ID"
+echo " numsPrice:  $NUMS_PRICE"
+echo " props:      $PROPS_JSON"
+echo "───────────────────────────────────────────────"
+echo ""
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "[dry-run] would execute:"
+  echo "  pnpm remotion:render:game '$PROPS_JSON'"
+  exit 0
+fi
+
+echo "→ rendering (this takes ~2–5 min, output blocks until done)…"
+pnpm remotion:render:game "$PROPS_JSON"
+
+OUTPUT_PATH="$REPO_ROOT/remotion/out/game-replay.mp4"
+if [[ -s "$OUTPUT_PATH" ]]; then
+  SIZE="$(ls -lh "$OUTPUT_PATH" | awk '{print $5}')"
+  echo ""
+  echo "✔ render complete"
+  echo "  file: $OUTPUT_PATH"
+  echo "  size: $SIZE"
+else
+  die "render finished but output missing or empty: $OUTPUT_PATH"
+fi

--- a/remotion/src/replay.tsx
+++ b/remotion/src/replay.tsx
@@ -263,7 +263,7 @@ export const Replay: React.FC<ReplayProps> = ({
             "linear-gradient(180deg, rgba(0, 0, 0, 0.32) 0%, rgba(0, 0, 0, 0.12) 100%)",
         }}
       >
-        <MotionConfig reducedMotion={isRendering ? "always" : "never"}>
+        <MotionConfig reducedMotion={"always"}>
           {isIntro && (
             <WelcomeScene close={() => {}} className="w-full h-full" />
           )}


### PR DESCRIPTION
## Summary

Adds a new agent skill that auto-renders a Nums Remotion replay for today's top game, plus a drive-by consistency fix for the replay `MotionConfig`. The skill resolves the target `gameId` from Torii (best reward or best score of the day, or a direct override) and auto-fetches the current NUMS/USD price from Ekubo — the same API the client app uses — then invokes `pnpm remotion:render:game` with the right props. Rationale: removes the friction of looking up the daily winner, computing the price, and hand-assembling the JSON props every time we want to share a highlight video.

## What's in it

- **`.agents/skills/render-daily-replay/SKILL.md`** — workflow, stored SQL queries, Ekubo price formula, gotchas, example conversation shapes.
- **`.agents/skills/render-daily-replay/scripts/render-daily-replay.sh`** — executable helper with modes `--best-reward`, `--best-score`, `--game-id <N>`, plus `--dry-run` and `--nums-price` escape hatches.
- **`remotion/src/replay.tsx`** — replace `reducedMotion={isRendering ? "always" : "never"}` with a flat `"always"`, so studio preview matches the rendered output. Previously the studio ran framer-motion springs at wall-clock time while the render stepped frame-by-frame, producing visibly different animations in the two environments.

Constants in the script (Torii URL, NUMS/USDC addresses, chainId, price formula) reference their source of truth (`client/.env.production`, `manifest_mainnet.json`, `client/src/context/prices.tsx`). The script aborts loudly on Ekubo errors instead of silently falling back to a stale default — a wrong price on the final video is a worse outcome than a loud failure.

## Testing notes

Smoke-tested all three modes end-to-end against live mainnet Torii and Ekubo via `--dry-run` (no actual render, but every resolution step verified):

- `--best-reward` → game 1523 (await-0x won 16606 NUMS), auto numsPrice 0.01129676
- `--best-score` → game 1523 (18 placed numbers), auto numsPrice 0.01129676
- `--game-id 1523` → skips Torii, auto numsPrice
- `--game-id 1523 --nums-price 0.012` → user override works

Error paths tested: no mode, conflicting modes, non-numeric `--game-id`, non-numeric `--nums-price` — all exit 1 with clear messages. Full `pnpm remotion:render:game` execution not run in CI (takes 2–5 min) but the final command is identical to the format already documented in the sibling `nums-remotion-replay` skill. The `replay.tsx` change is a one-line conditional removal and affects only the studio preview path.