### PR TITLE
feat: draw power-ups before game-over check

### DIFF
--- a/client/src/models/game.ts
+++ b/client/src/models/game.ts
@@ -740,6 +740,15 @@ export class Game {
       cloneSlots.push(this.number);
       this.next_number = this.next(cloneSlots, rand);
     }
+    // [Effect] Draw new powers if possible
+    if (this.isDrawable()) {
+      if (this._powerDrawQueue && this._powerDrawQueue.length > 0) {
+        this.selectable_powers = this._powerDrawQueue.shift()!;
+      } else {
+        const powerIndexes = Power.draw(rand.nextSeed(), DEFAULT_DRAW_COUNT);
+        this.selectable_powers = powerIndexes.map((index) => Power.from(index));
+      }
+    }
     // [Effect] Assess game over
     // [Info] Game is over if:
     // - number cannot be placed
@@ -749,15 +758,6 @@ export class Game {
       // For practice mode, we use a mock timestamp
       const mockTimestamp = Math.floor(Date.now() / 1000);
       this.over = mockTimestamp;
-    }
-    // [Effect] Draw new powers if possible
-    if (this.over === 0 && this.isDrawable()) {
-      if (this._powerDrawQueue && this._powerDrawQueue.length > 0) {
-        this.selectable_powers = this._powerDrawQueue.shift()!;
-      } else {
-        const powerIndexes = Power.draw(rand.nextSeed(), DEFAULT_DRAW_COUNT);
-        this.selectable_powers = powerIndexes.map((index) => Power.from(index));
-      }
     }
   }
 

--- a/contracts/src/models/game.cairo
+++ b/contracts/src/models/game.cairo
@@ -319,6 +319,11 @@ pub impl GameImpl of GameTrait {
             clone_slots.append(self.number);
             self.next_number = self.next(@clone_slots, ref rand);
         }
+        // [Effect] Draw new powers if possible
+        if self.is_drawable() {
+            let powers = PowerTrait::draw(rand.next_seed(), DEFAULT_DRAW_COUNT);
+            self.selectable_powers = Packer::pack(powers, POWER_SIZE)
+        }
         // [Effect] Assess game over
         // [Info] Game is over if:
         // - number cannot be placed
@@ -329,11 +334,6 @@ pub impl GameImpl of GameTrait {
         } else {
             self.over
         };
-        // [Effect] Draw new powers if possible
-        if self.over == 0 && self.is_drawable() {
-            let powers = PowerTrait::draw(rand.next_seed(), DEFAULT_DRAW_COUNT);
-            self.selectable_powers = Packer::pack(powers, POWER_SIZE)
-        }
     }
 
     /// Claims the game.

--- a/docs/pages/game-rules/index.mdx
+++ b/docs/pages/game-rules/index.mdx
@@ -7,35 +7,63 @@ The game is a skill-based number placement game. Players place 18 numbers (betwe
 <div className="docs-flow">
   <div className="docs-flow__step">
     <span className="docs-flow__num">1</span>
-    <div className="docs-flow__content">Players can select from several entry bundles, which offer a progressively lower cost per game when purchasing up to 10 entries at a time</div>
+    <div className="docs-flow__content">
+      Players can select from several entry bundles, which offer a progressively
+      lower cost per game when purchasing up to 10 entries at a time
+    </div>
   </div>
   <div className="docs-flow__step">
     <span className="docs-flow__num">2</span>
-    <div className="docs-flow__content">The system draws 18 unique numbers one at a time between <strong>1</strong> and <strong>999</strong></div>
+    <div className="docs-flow__content">
+      The system draws 18 unique numbers one at a time between{" "}
+      <strong>1</strong> and <strong>999</strong>
+    </div>
   </div>
   <div className="docs-flow__step">
     <span className="docs-flow__num">3</span>
-    <div className="docs-flow__content">The player always sees the <strong>current number</strong> to place and the <strong>upcoming number</strong> (peek)</div>
+    <div className="docs-flow__content">
+      The player always sees the <strong>current number</strong> to place and
+      the <strong>upcoming number</strong> (peek)
+    </div>
   </div>
   <div className="docs-flow__step">
     <span className="docs-flow__num">4</span>
-    <div className="docs-flow__content">The player strategically places the current number into an available slot. They can reshape their fate by using <strong>power-ups</strong> and navigating <strong>traps</strong></div>
+    <div className="docs-flow__content">
+      The player strategically places the current number into an available slot.
+      They can reshape their fate by using <strong>power-ups</strong> and
+      navigating <strong>traps</strong>
+    </div>
   </div>
   <div className="docs-flow__step">
     <span className="docs-flow__num">5</span>
-    <div className="docs-flow__content">Once placed, a number cannot be moved. Players unlock power-ups by successfully filling designated milestone slots on the board. These power-ups are banked for later use, and deciding exactly when to deploy them is a key part of the strategy</div>
+    <div className="docs-flow__content">
+      Once placed, a number cannot be moved. Players unlock power-ups by
+      successfully filling designated milestone slots on the board. These
+      power-ups are banked for later use, and deciding exactly when to deploy
+      them is a key part of the strategy
+    </div>
   </div>
   <div className="docs-flow__step">
     <span className="docs-flow__num">6</span>
-    <div className="docs-flow__content">All placed numbers must stay in ascending order from left to right. Two equal numbers can be placed consecutively</div>
+    <div className="docs-flow__content">
+      All placed numbers must stay in ascending order from left to right. Two
+      equal numbers can be placed consecutively
+    </div>
   </div>
   <div className="docs-flow__step">
     <span className="docs-flow__num">7</span>
-    <div className="docs-flow__content">Complete the game and <strong>claim your rewards</strong></div>
+    <div className="docs-flow__content">
+      Complete the game and <strong>claim your rewards</strong>
+    </div>
   </div>
 </div>
 
-<p><em>Skill matters: your placement choices, power-up timing, and trap management drive your results.</em></p>
+<p>
+  <em>
+    Skill matters: your placement choices, power-up timing, and trap management
+    drive your results.
+  </em>
+</p>
 
 ## Win conditions
 
@@ -45,5 +73,10 @@ Even if the game ends before completion, you can earn **partial rewards** based 
 
 ## Lose conditions
 
-The game ends when the current number cannot be placed anywhere without breaking the ascending order, and you have no power-ups left to use.
+The game ends when **all** of the following are true:
 
+- The current number cannot be placed anywhere without breaking the ascending order
+- You have no power-ups available to use
+- No power-up draw is pending
+
+If you reach a power-up milestone (level 6 or 12) on the same turn the board would otherwise be blocked, you are offered a power-up draw **before** the game checks for a loss. This gives you a last chance to pick and use a power-up to save your run.

--- a/docs/pages/release-notes.mdx
+++ b/docs/pages/release-notes.mdx
@@ -1,0 +1,62 @@
+# Release Notes
+
+Changelog of game updates and player-facing improvements for NUMS.
+
+---
+
+## April 9, 2026
+
+### Referral Leaderboard
+
+A new tabbed leaderboard lets you switch between **Nums** (score ranking) and **Referrals** (referral ranking). Track your referral performance alongside your game scores.
+
+### Bug Fixes
+
+- Fixed an issue where the `game_started` event never fired, which could cause tracking inconsistencies.
+
+---
+
+## April 3, 2026
+
+### Power-Up Draw Stages Rebalanced
+
+Power-up draws now occur at levels **6** and **12** (previously 4, 8, 12). This reduces the total number of draws from 3 to 2 but spaces them out more evenly across the game.
+
+---
+
+## April 2, 2026
+
+### Bug Fixes
+
+- Fixed the welcome page SlotCounter animation that was broken on initial site load.
+- Improved cross-browser compatibility — resolved React key warnings and improved WebKit resilience.
+- Fixed toast notification font sizes.
+
+---
+
+## April 1, 2026
+
+### Events Clickable
+
+Events in the activity feed are now clickable links for easier navigation.
+
+### Bug Fixes
+
+- Fixed referral tracking.
+- Fixed responsive grid padding on achievement cards.
+- Fixed score submission weight calculation.
+- Fixed purchase title display.
+
+---
+
+## March 31, 2026
+
+### Stage Unlocked State
+
+The Stage component now shows an **unlocked** visual state, making it clearer which stages you have reached.
+
+### Bug Fixes
+
+- Fixed a chain reaction issue where certain trap combinations could cause unexpected behavior.
+- Fixed VRF (randomness) verification.
+- Fixed game icon display.

--- a/manifest_mainnet.json
+++ b/manifest_mainnet.json
@@ -81,7 +81,7 @@
     },
     {
       "address": "0x575bd762ac42b1386a8da0d07f646ac631786eab359f3f39f1b53208208ab9c",
-      "class_hash": "0x6be0f4f3a3dca659e2c901859449b7145d6cd74e32f2fc9db36346ba802979b",
+      "class_hash": "0x6c5db913f205edf4482481c75ac4c744b641e8733e17a53071cc55ff7814336",
       "init_calldata": [],
       "tag": "NUMS-Play",
       "selector": "0x233dcec2c076248704b3dfda04e697ed4bc600be123cefd04283739df495e3f",

--- a/manifest_sepolia.json
+++ b/manifest_sepolia.json
@@ -101,7 +101,7 @@
     },
     {
       "address": "0x105dc0e5838d4893fa058ceb40b79f5e4c87d05c5d4a6c6a7f92ec4b0216c48",
-      "class_hash": "0x6be0f4f3a3dca659e2c901859449b7145d6cd74e32f2fc9db36346ba802979b",
+      "class_hash": "0xdb71b2b2d7a74fae4639f10d25e361c7e1202a2ca0e9f4445995cddd46e346",
       "init_calldata": [],
       "tag": "NUMS-Play",
       "selector": "0x233dcec2c076248704b3dfda04e697ed4bc600be123cefd04283739df495e3f",

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -116,6 +116,7 @@ export default defineConfig({
         { text: "Randomness", link: "/game-rules/randomness" },
       ],
     },
+    { text: "Release Notes", link: "/release-notes" },
     { text: "Token", link: "/token" },
     {
       text: "Governance",


### PR DESCRIPTION
## Summary

- **Game mechanic**: Power-up draws now happen **before** the game-over check in `update()`. Players reaching a draw milestone (level 6 or 12) on a blocked board get a last chance to pick and use a power-up to save their run.
- **Docs**: Added a Release Notes page with dated entries (March 31 – April 9) and updated the Lose Conditions section in Game Rules to reflect the new mechanic.
- **Manifest**: Updated sepolia class hash for NUMS-Play contract.

## Changes

| File | What |
|---|---|
| `contracts/src/models/game.cairo` | Move power draw before game-over assessment, remove redundant `over == 0` guard |
| `client/src/models/game.ts` | Mirror the same reorder in the TypeScript client |
| `manifest_sepolia.json` | Updated NUMS-Play class hash |
| `docs/pages/release-notes.mdx` | New release notes page |
| `docs/pages/game-rules/index.mdx` | Updated lose conditions |
| `vocs.config.ts` | Added Release Notes to sidebar |

## Testing

- 155/155 Cairo tests pass (`scarb test`)
- No LSP diagnostics on changed files