### PR TITLE
feat: add release notes modal with version-based persistence

### DIFF
--- a/.agents/skills/add-release-note/SKILL.md
+++ b/.agents/skills/add-release-note/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: add-release-note
+description: Add a new release note entry. Keeps the client data file and the docs MDX page in sync, and bumps the version so the in-game modal re-appears for all players.
+---
+
+# Add Release Note
+
+Two files must **always** be updated together:
+
+| File                               | Purpose                                       |
+| ---------------------------------- | --------------------------------------------- |
+| `client/src/data/release-notes.ts` | Structured data rendered in the in-game modal |
+| `docs/pages/release-notes.mdx`     | Public documentation page                     |
+
+## Steps
+
+### 1. Add the entry in the data file
+
+Open `client/src/data/release-notes.ts` and insert a new object **at the top** of the `RELEASE_NOTES` array:
+
+```ts
+{
+  date: "April 11, 2026",          // human-readable date
+  sections: [
+    {
+      title: "Features",            // or "Bug Fixes"
+      items: [
+        "Description of the change.",
+      ],
+    },
+  ],
+},
+```
+
+Every item must be a bullet point string in the `items` array. Group items under `"Features"` or `"Bug Fixes"` sections.
+
+### 2. Bump the version
+
+In the same file, update `RELEASE_NOTES_VERSION` to match the new entry date in ISO format:
+
+```ts
+export const RELEASE_NOTES_VERSION = "2026-04-11";
+```
+
+This is what triggers the modal to re-appear. The `useReleaseNotes` hook compares this value against the version stored in the player's localStorage (`nums-release-notes-version`). If they differ, the modal is shown.
+
+### 3. Mirror in the docs
+
+Open `docs/pages/release-notes.mdx` and add a matching section **at the top**, after the `---` separator:
+
+```mdx
+## April 11, 2026
+
+### Features
+
+- Description of the change.
+
+---
+```
+
+Use the same section headings (`### Features`, `### Bug Fixes`) and the same bullet point text as in the data file.
+
+## Checklist
+
+- [ ] New entry added at the top of `RELEASE_NOTES` array
+- [ ] `RELEASE_NOTES_VERSION` bumped to new date
+- [ ] Matching entry added at the top of `docs/pages/release-notes.mdx`
+- [ ] Bullet point text is identical in both files
+- [ ] `pnpm run type:check` passes in `client/`

--- a/client/src/components/containers/index.ts
+++ b/client/src/components/containers/index.ts
@@ -28,3 +28,4 @@ export * from "./tutorial-anchor-portal";
 export * from "./achievements";
 export * from "./airdrop";
 export * from "./tos";
+export * from "./release-notes";

--- a/client/src/components/containers/release-notes.tsx
+++ b/client/src/components/containers/release-notes.tsx
@@ -28,18 +28,15 @@ const releaseNotesVariants = cva(
   },
 );
 
-function Section({ title, content, items }: ReleaseNoteSection) {
+function Section({ title, items }: ReleaseNoteSection) {
   return (
     <div className="flex flex-col gap-1.5">
       <h4 className="text-lg/5 font-semibold">{title}</h4>
-      {content && <p>{content}</p>}
-      {items && items.length > 0 && (
-        <ul className="list-disc pl-5 flex flex-col gap-1">
-          {items.map((item, i) => (
-            <li key={i}>{item}</li>
-          ))}
-        </ul>
-      )}
+      <ul className="list-disc pl-5 flex flex-col gap-1">
+        {items.map((item, i) => (
+          <li key={i}>{item}</li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/client/src/components/containers/release-notes.tsx
+++ b/client/src/components/containers/release-notes.tsx
@@ -1,0 +1,104 @@
+import { cn } from "@/lib/utils";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Button } from "@/components/ui/button";
+import {
+  RELEASE_NOTES,
+  type ReleaseNoteEntry,
+  type ReleaseNoteSection,
+} from "@/data/release-notes";
+
+export interface ReleaseNotesProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof releaseNotesVariants> {
+  onAcknowledge: () => void;
+}
+
+const releaseNotesVariants = cva(
+  "select-none relative flex flex-col p-6 md:p-12 gap-6 md:gap-10 w-full md:h-[60vh] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default:
+          "rounded-2xl md:rounded-3xl bg-black-200 border-2 border-black-300 shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] backdrop-blur-[4px]",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Section({ title, content, items }: ReleaseNoteSection) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <h4 className="text-lg/5 font-semibold">{title}</h4>
+      {content && <p>{content}</p>}
+      {items && items.length > 0 && (
+        <ul className="list-disc pl-5 flex flex-col gap-1">
+          {items.map((item, i) => (
+            <li key={i}>{item}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function Entry({ date, sections }: ReleaseNoteEntry) {
+  return (
+    <div className="flex flex-col gap-3">
+      <h3
+        className="text-xl/5 font-bold uppercase tracking-wide"
+        style={{ textShadow: "1px 1px 0px rgba(0, 0, 0, 0.15)" }}
+      >
+        {date}
+      </h3>
+      {sections.map((section, i) => (
+        <Section key={i} {...section} />
+      ))}
+    </div>
+  );
+}
+
+export const ReleaseNotes = ({
+  onAcknowledge,
+  variant,
+  className,
+  ...props
+}: ReleaseNotesProps) => {
+  return (
+    <div
+      className={cn(releaseNotesVariants({ variant, className }))}
+      {...props}
+    >
+      <h2
+        className="text-[36px]/6 md:text-[48px]/[33px] uppercase tracking-wider translate-y-0.5"
+        style={{ textShadow: "2px 2px 0px rgba(0, 0, 0, 0.25)" }}
+      >
+        Release Notes
+      </h2>
+
+      <div
+        className="flex flex-col gap-6 overflow-y-auto font-sans text-base/5 text-white-100"
+        style={{ scrollbarWidth: "none" }}
+      >
+        {RELEASE_NOTES.map((entry, i) => (
+          <Entry key={i} {...entry} />
+        ))}
+      </div>
+
+      <Button
+        variant="tertiary"
+        className="min-h-12 w-full"
+        onClick={onAcknowledge}
+      >
+        <span
+          className="px-1 text-[28px]/[19px] tracking-wide translate-y-0.5"
+          style={{ textShadow: "2px 2px 0px rgba(0, 0, 0, 0.24)" }}
+        >
+          Got it
+        </span>
+      </Button>
+    </div>
+  );
+};

--- a/client/src/data/release-notes.ts
+++ b/client/src/data/release-notes.ts
@@ -21,7 +21,7 @@ export const RELEASE_NOTES: ReleaseNoteEntry[] = [
       {
         title: "Features",
         items: [
-          "Added an in-game release notes modal that appears on new updates so you never miss what changed.",
+          "Changed lose conditions on power-up draw stages \u2014 you can no longer lose on a stage where you draw a power-up.",
         ],
       },
     ],

--- a/client/src/data/release-notes.ts
+++ b/client/src/data/release-notes.ts
@@ -1,0 +1,95 @@
+export interface ReleaseNoteSection {
+  title: string;
+  content?: string;
+  items?: string[];
+}
+
+export interface ReleaseNoteEntry {
+  date: string;
+  sections: ReleaseNoteSection[];
+}
+
+/**
+ * Bump this value whenever new release notes are added.
+ * The modal will re-appear for users who haven't seen this version yet.
+ */
+export const RELEASE_NOTES_VERSION = "2026-04-09";
+
+export const RELEASE_NOTES: ReleaseNoteEntry[] = [
+  {
+    date: "April 9, 2026",
+    sections: [
+      {
+        title: "Referral Leaderboard",
+        content:
+          "A new tabbed leaderboard lets you switch between Nums (score ranking) and Referrals (referral ranking). Track your referral performance alongside your game scores.",
+      },
+      {
+        title: "Bug Fixes",
+        items: [
+          "Fixed an issue where the game_started event never fired, which could cause tracking inconsistencies.",
+        ],
+      },
+    ],
+  },
+  {
+    date: "April 3, 2026",
+    sections: [
+      {
+        title: "Power-Up Draw Stages Rebalanced",
+        content:
+          "Power-up draws now occur at levels 6 and 12 (previously 4, 8, 12). This reduces the total number of draws from 3 to 2 but spaces them out more evenly across the game.",
+      },
+    ],
+  },
+  {
+    date: "April 2, 2026",
+    sections: [
+      {
+        title: "Bug Fixes",
+        items: [
+          "Fixed the welcome page SlotCounter animation that was broken on initial site load.",
+          "Improved cross-browser compatibility \u2014 resolved React key warnings and improved WebKit resilience.",
+          "Fixed toast notification font sizes.",
+        ],
+      },
+    ],
+  },
+  {
+    date: "April 1, 2026",
+    sections: [
+      {
+        title: "Events Clickable",
+        content:
+          "Events in the activity feed are now clickable links for easier navigation.",
+      },
+      {
+        title: "Bug Fixes",
+        items: [
+          "Fixed referral tracking.",
+          "Fixed responsive grid padding on achievement cards.",
+          "Fixed score submission weight calculation.",
+          "Fixed purchase title display.",
+        ],
+      },
+    ],
+  },
+  {
+    date: "March 31, 2026",
+    sections: [
+      {
+        title: "Stage Unlocked State",
+        content:
+          "The Stage component now shows an unlocked visual state, making it clearer which stages you have reached.",
+      },
+      {
+        title: "Bug Fixes",
+        items: [
+          "Fixed a chain reaction issue where certain trap combinations could cause unexpected behavior.",
+          "Fixed VRF (randomness) verification.",
+          "Fixed game icon display.",
+        ],
+      },
+    ],
+  },
+];

--- a/client/src/data/release-notes.ts
+++ b/client/src/data/release-notes.ts
@@ -1,7 +1,6 @@
 export interface ReleaseNoteSection {
   title: string;
-  content?: string;
-  items?: string[];
+  items: string[];
 }
 
 export interface ReleaseNoteEntry {
@@ -13,16 +12,28 @@ export interface ReleaseNoteEntry {
  * Bump this value whenever new release notes are added.
  * The modal will re-appear for users who haven't seen this version yet.
  */
-export const RELEASE_NOTES_VERSION = "2026-04-09";
+export const RELEASE_NOTES_VERSION = "2026-04-10";
 
 export const RELEASE_NOTES: ReleaseNoteEntry[] = [
+  {
+    date: "April 10, 2026",
+    sections: [
+      {
+        title: "Features",
+        items: [
+          "Added an in-game release notes modal that appears on new updates so you never miss what changed.",
+        ],
+      },
+    ],
+  },
   {
     date: "April 9, 2026",
     sections: [
       {
-        title: "Referral Leaderboard",
-        content:
-          "A new tabbed leaderboard lets you switch between Nums (score ranking) and Referrals (referral ranking). Track your referral performance alongside your game scores.",
+        title: "Features",
+        items: [
+          "A new tabbed leaderboard lets you switch between Nums (score ranking) and Referrals (referral ranking).",
+        ],
       },
       {
         title: "Bug Fixes",
@@ -36,9 +47,10 @@ export const RELEASE_NOTES: ReleaseNoteEntry[] = [
     date: "April 3, 2026",
     sections: [
       {
-        title: "Power-Up Draw Stages Rebalanced",
-        content:
+        title: "Features",
+        items: [
           "Power-up draws now occur at levels 6 and 12 (previously 4, 8, 12). This reduces the total number of draws from 3 to 2 but spaces them out more evenly across the game.",
+        ],
       },
     ],
   },
@@ -59,9 +71,10 @@ export const RELEASE_NOTES: ReleaseNoteEntry[] = [
     date: "April 1, 2026",
     sections: [
       {
-        title: "Events Clickable",
-        content:
+        title: "Features",
+        items: [
           "Events in the activity feed are now clickable links for easier navigation.",
+        ],
       },
       {
         title: "Bug Fixes",
@@ -78,9 +91,10 @@ export const RELEASE_NOTES: ReleaseNoteEntry[] = [
     date: "March 31, 2026",
     sections: [
       {
-        title: "Stage Unlocked State",
-        content:
+        title: "Features",
+        items: [
           "The Stage component now shows an unlocked visual state, making it clearer which stages you have reached.",
+        ],
       },
       {
         title: "Bug Fixes",

--- a/client/src/hooks/release-notes.ts
+++ b/client/src/hooks/release-notes.ts
@@ -1,0 +1,17 @@
+import { useCallback, useState } from "react";
+import { RELEASE_NOTES_VERSION } from "@/data/release-notes";
+
+const RELEASE_NOTES_KEY = "nums-release-notes-version";
+
+export const useReleaseNotes = () => {
+  const [seen, setSeen] = useState<boolean>(
+    () => localStorage.getItem(RELEASE_NOTES_KEY) === RELEASE_NOTES_VERSION,
+  );
+
+  const acknowledge = useCallback(() => {
+    localStorage.setItem(RELEASE_NOTES_KEY, RELEASE_NOTES_VERSION);
+    setSeen(true);
+  }, []);
+
+  return { seen, acknowledge };
+};

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -35,7 +35,9 @@ import { useWelcome } from "@/context/welcome";
 import { MediaButton, MediaContent, Toaster } from "@/components/elements";
 import { Settings } from "@/components/containers/settings";
 import { Tos } from "@/components/containers/tos";
+import { ReleaseNotes } from "@/components/containers/release-notes";
 import { useTos } from "@/hooks/tos";
+import { useReleaseNotes } from "@/hooks/release-notes";
 import { Events } from "@/components/containers/events";
 import { WelcomeScene } from "@/components/scenes";
 import { useAudio } from "@/context/audio";
@@ -70,6 +72,8 @@ export const Main = ({ children }: MainProps) => {
   const [initialPathname] = useState(() => pathname);
   const { isDismissed, isDismissing, dismiss } = useWelcome();
   const { accepted: tosAccepted, accept: acceptTos } = useTos();
+  const { seen: releaseNotesSeen, acknowledge: acknowledgeReleaseNotes } =
+    useReleaseNotes();
   const { account, connector } = useAccount();
   const { find, loading } = useControllers();
   const headerData = useHeader();
@@ -695,6 +699,17 @@ export const Main = ({ children }: MainProps) => {
           <div className="absolute inset-0 z-50 flex-1 bg-black-700 backdrop-blur-[4px]">
             <div className="absolute inset-0 z-50 m-2 md:m-6 flex-1 flex items-center justify-center">
               <Tos onAccept={acceptTos} className="h-full md:max-w-[768px]" />
+            </div>
+          </div>
+        )}
+
+        {tosAccepted && !releaseNotesSeen && isDismissed && (
+          <div className="absolute inset-0 z-50 flex-1 bg-black-700 backdrop-blur-[4px]">
+            <div className="absolute inset-0 z-50 m-2 md:m-6 flex-1 flex items-center justify-center">
+              <ReleaseNotes
+                onAcknowledge={acknowledgeReleaseNotes}
+                className="h-full md:max-w-[768px]"
+              />
             </div>
           </div>
         )}

--- a/docs/pages/release-notes.mdx
+++ b/docs/pages/release-notes.mdx
@@ -14,9 +14,9 @@ Changelog of game updates and player-facing improvements for NUMS.
 
 ## April 9, 2026
 
-### Referral Leaderboard
+### Features
 
-A new tabbed leaderboard lets you switch between **Nums** (score ranking) and **Referrals** (referral ranking). Track your referral performance alongside your game scores.
+- A new tabbed leaderboard lets you switch between **Nums** (score ranking) and **Referrals** (referral ranking).
 
 ### Bug Fixes
 
@@ -26,9 +26,9 @@ A new tabbed leaderboard lets you switch between **Nums** (score ranking) and **
 
 ## April 3, 2026
 
-### Power-Up Draw Stages Rebalanced
+### Features
 
-Power-up draws now occur at levels **6** and **12** (previously 4, 8, 12). This reduces the total number of draws from 3 to 2 but spaces them out more evenly across the game.
+- Power-up draws now occur at levels **6** and **12** (previously 4, 8, 12). This reduces the total number of draws from 3 to 2 but spaces them out more evenly across the game.
 
 ---
 
@@ -44,9 +44,9 @@ Power-up draws now occur at levels **6** and **12** (previously 4, 8, 12). This 
 
 ## April 1, 2026
 
-### Events Clickable
+### Features
 
-Events in the activity feed are now clickable links for easier navigation.
+- Events in the activity feed are now clickable links for easier navigation.
 
 ### Bug Fixes
 
@@ -59,9 +59,9 @@ Events in the activity feed are now clickable links for easier navigation.
 
 ## March 31, 2026
 
-### Stage Unlocked State
+### Features
 
-The Stage component now shows an **unlocked** visual state, making it clearer which stages you have reached.
+- The Stage component now shows an **unlocked** visual state, making it clearer which stages you have reached.
 
 ### Bug Fixes
 

--- a/docs/pages/release-notes.mdx
+++ b/docs/pages/release-notes.mdx
@@ -4,6 +4,14 @@ Changelog of game updates and player-facing improvements for NUMS.
 
 ---
 
+## April 10, 2026
+
+### Features
+
+- Added an in-game release notes modal that appears on new updates so you never miss what changed.
+
+---
+
 ## April 9, 2026
 
 ### Referral Leaderboard

--- a/docs/pages/release-notes.mdx
+++ b/docs/pages/release-notes.mdx
@@ -8,7 +8,7 @@ Changelog of game updates and player-facing improvements for NUMS.
 
 ### Features
 
-- Added an in-game release notes modal that appears on new updates so you never miss what changed.
+- Changed lose conditions on power-up draw stages — you can no longer lose on a stage where you draw a power-up.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a release notes modal reusing the ToS modal pattern (same styling, layout, backdrop)
- Tracks last-seen version via localStorage — the modal re-appears when `RELEASE_NOTES_VERSION` is bumped
- Shows after ToS acceptance and welcome dismissal, so it never blocks the ToS flow
- All entries (features and fixes) use bullet points for consistency
- Includes the April 10 release note (power-up draw stage lose conditions change)
- Docs (`release-notes.mdx`) updated to match the same bullet point format
- Adds an `add-release-note` agent skill documenting how to add new entries and keep data + docs in sync

## How to add new release notes

1. Add a new entry at the top of the `RELEASE_NOTES` array in `client/src/data/release-notes.ts`
2. Bump `RELEASE_NOTES_VERSION` to the new date (e.g. `"2026-04-11"`)
3. Mirror the entry at the top of `docs/pages/release-notes.mdx`

The modal will automatically re-appear for all players.

## Files changed

- `client/src/data/release-notes.ts` — structured release notes data + version constant
- `client/src/hooks/release-notes.ts` — `useReleaseNotes` hook (localStorage persistence)
- `client/src/components/containers/release-notes.tsx` — `ReleaseNotes` component
- `client/src/components/containers/index.ts` — barrel export
- `client/src/pages/index.tsx` — integration in Main layout
- `docs/pages/release-notes.mdx` — bullet point format for features
- `.agents/skills/add-release-note/SKILL.md` — agent skill for adding release notes