### PR TITLE
Add static asset caching for Nums web app

### DIFF
--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -1,0 +1,137 @@
+const APP_PREFIX = "nums";
+const VERSION = new URL(self.location.href).searchParams.get("v") || "dev";
+const DOCUMENT_CACHE = `${APP_PREFIX}-document-${VERSION}`;
+const STATIC_CACHE = `${APP_PREFIX}-static-${VERSION}`;
+const CACHE_PREFIX = `${APP_PREFIX}-`;
+const APP_SHELL_PATH = "/";
+const STATIC_PATH_PREFIXES = ["/assets/", "/fontawesome/"];
+const STATIC_EXTENSIONS = [
+  ".js",
+  ".css",
+  ".ico",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".svg",
+  ".gif",
+  ".webp",
+  ".avif",
+  ".woff",
+  ".woff2",
+  ".ttf",
+  ".otf",
+  ".json",
+];
+
+const isHttpRequest = (url) => url.protocol === "http:" || url.protocol === "https:";
+const isSameOrigin = (url) => url.origin === self.location.origin;
+const isStaticAsset = (url) => {
+  return (
+    STATIC_PATH_PREFIXES.some((prefix) => url.pathname.startsWith(prefix)) ||
+    STATIC_EXTENSIONS.some((extension) => url.pathname.endsWith(extension))
+  );
+};
+
+const shouldBypass = (request, url) => {
+  if (request.method !== "GET") return true;
+  if (!isHttpRequest(url)) return true;
+  if (!isSameOrigin(url)) return true;
+  if (url.pathname === "/sw.js") return true;
+  if (url.pathname.startsWith("/api/")) return true;
+  if (url.pathname.startsWith("/_vercel/")) return true;
+  return false;
+};
+
+const putIfOk = async (cacheName, request, response) => {
+  if (!response || !response.ok) return response;
+  const cache = await caches.open(cacheName);
+  await cache.put(request, response.clone());
+  return response;
+};
+
+const cacheFirst = async (request) => {
+  const cache = await caches.open(STATIC_CACHE);
+  const cached = await cache.match(request);
+
+  const networkFetch = fetch(request)
+    .then((response) => putIfOk(STATIC_CACHE, request, response))
+    .catch(() => undefined);
+
+  if (cached) {
+    return cached;
+  }
+
+  const response = await networkFetch;
+  if (response) {
+    return response;
+  }
+
+  return Response.error();
+};
+
+const networkFirstDocument = async (request) => {
+  const cache = await caches.open(DOCUMENT_CACHE);
+
+  try {
+    const response = await fetch(request);
+    await putIfOk(DOCUMENT_CACHE, request, response);
+    if (request.url !== self.location.origin + APP_SHELL_PATH) {
+      await putIfOk(
+        DOCUMENT_CACHE,
+        new Request(APP_SHELL_PATH, { method: "GET" }),
+        response,
+      );
+    }
+    return response;
+  } catch {
+    const cached = (await cache.match(request)) || (await cache.match(APP_SHELL_PATH));
+    return cached || Response.error();
+  }
+};
+
+self.addEventListener("install", (event) => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches
+      .open(DOCUMENT_CACHE)
+      .then((cache) => cache.add(new Request(APP_SHELL_PATH, { cache: "reload" })))
+      .catch(() => undefined),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      const cacheKeys = await caches.keys();
+      await Promise.all(
+        cacheKeys
+          .filter(
+            (cacheKey) =>
+              cacheKey.startsWith(CACHE_PREFIX) &&
+              cacheKey !== DOCUMENT_CACHE &&
+              cacheKey !== STATIC_CACHE,
+          )
+          .map((cacheKey) => caches.delete(cacheKey)),
+      );
+      await self.clients.claim();
+    })(),
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  if (shouldBypass(request, url)) {
+    return;
+  }
+
+  if (request.mode === "navigate") {
+    event.respondWith(networkFirstDocument(request));
+    return;
+  }
+
+  if (isStaticAsset(url)) {
+    event.respondWith(cacheFirst(request));
+  }
+});

--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -90,13 +90,18 @@ const networkFirstDocument = async (request) => {
 };
 
 self.addEventListener("install", (event) => {
-  self.skipWaiting();
   event.waitUntil(
     caches
       .open(DOCUMENT_CACHE)
       .then((cache) => cache.add(new Request(APP_SHELL_PATH, { cache: "reload" })))
       .catch(() => undefined),
   );
+});
+
+self.addEventListener("message", (event) => {
+  if (event.data?.type === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
 });
 
 self.addEventListener("activate", (event) => {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 import { inject } from "@vercel/analytics";
+import { registerServiceWorker } from "./register-service-worker";
 
 if (
   typeof window !== "undefined" &&
@@ -10,6 +11,8 @@ if (
 ) {
   inject();
 }
+
+registerServiceWorker();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/client/src/register-service-worker.ts
+++ b/client/src/register-service-worker.ts
@@ -1,0 +1,22 @@
+const canRegisterServiceWorker = () => {
+  return (
+    import.meta.env.PROD &&
+    typeof window !== "undefined" &&
+    "serviceWorker" in navigator
+  );
+};
+
+export const registerServiceWorker = () => {
+  if (!canRegisterServiceWorker()) {
+    return;
+  }
+
+  window.addEventListener("load", () => {
+    const version = encodeURIComponent(__APP_VERSION__);
+    void navigator.serviceWorker
+      .register(`/sw.js?v=${version}`, { scope: "/" })
+      .catch((error: unknown) => {
+        console.error("Failed to register service worker", error);
+      });
+  });
+};

--- a/client/src/register-service-worker.ts
+++ b/client/src/register-service-worker.ts
@@ -1,9 +1,65 @@
+import { toast } from "sonner";
+
 const canRegisterServiceWorker = () => {
   return (
     import.meta.env.PROD &&
     typeof window !== "undefined" &&
     "serviceWorker" in navigator
   );
+};
+
+const UPDATE_TOAST_ID = "app-update-ready";
+
+const promptForUpdate = (registration: ServiceWorkerRegistration) => {
+  const reloadWithUpdate = () => {
+    let refreshing = false;
+    navigator.serviceWorker.addEventListener("controllerchange", () => {
+      if (refreshing) {
+        return;
+      }
+      refreshing = true;
+      window.location.reload();
+    });
+
+    registration.waiting?.postMessage({ type: "SKIP_WAITING" });
+  };
+
+  toast("New version available", {
+    id: UPDATE_TOAST_ID,
+    duration: Number.POSITIVE_INFINITY,
+    description: "Reload to use the latest frontend update.",
+    action: {
+      label: "Reload",
+      onClick: reloadWithUpdate,
+    },
+    cancel: {
+      label: "Later",
+      onClick: () => {},
+    },
+  });
+};
+
+const watchForUpdates = (registration: ServiceWorkerRegistration) => {
+  if (registration.waiting && navigator.serviceWorker.controller) {
+    promptForUpdate(registration);
+  }
+
+  registration.addEventListener("updatefound", () => {
+    const installing = registration.installing;
+    if (!installing) {
+      return;
+    }
+
+    installing.addEventListener("statechange", () => {
+      if (
+        installing.state === "installed" &&
+        navigator.serviceWorker.controller &&
+        registration.waiting
+      ) {
+        promptForUpdate(registration);
+      }
+    });
+  });
 };
 
 export const registerServiceWorker = () => {
@@ -15,6 +71,9 @@ export const registerServiceWorker = () => {
     const version = encodeURIComponent(__APP_VERSION__);
     void navigator.serviceWorker
       .register(`/sw.js?v=${version}`, { scope: "/" })
+      .then((registration) => {
+        watchForUpdates(registration);
+      })
       .catch((error: unknown) => {
         console.error("Failed to register service worker", error);
       });

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+declare const __COMMIT_SHA__: string;
+declare const __APP_VERSION__: string;

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
   ],
   define: {
     __COMMIT_SHA__: JSON.stringify(COMMIT_SHA),
+    __APP_VERSION__: JSON.stringify(COMMIT_SHA),
   },
   server: {
     port: process.env.NODE_ENV === "development" ? 3003 : undefined,


### PR DESCRIPTION
## Summary
- register a production service worker with deploy-scoped cache versions
- cache same-origin HTML and static assets for faster iOS webview reloads
- keep API, auth, and iframe traffic out of the cache layer

## Verification
- pnpm --dir client build:check