### PR TITLE
Add mobile notification support

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,6 +12,8 @@ import { Provider as JotaiProvider } from "jotai";
 import { Route, BrowserRouter as Router, Routes } from "react-router-dom";
 import { chains, DEFAULT_CHAIN_ID } from "@/config";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { NativeNotificationBridge } from "@/components/containers/native-notification-bridge";
+import { NotificationEvents } from "@/components/containers/notification-events";
 import { AudioProvider } from "./context/audio";
 import { SoundProvider } from "./context/sound";
 import { ThemeProvider } from "./context/theme";
@@ -104,6 +106,7 @@ function DeployGate() {
         v7_relativeSplatPath: true,
       }}
     >
+      <NotificationEvents />
       <Routes>
         <Route path="/support" element={<Support />} />
         <Route path="/*" element={<AuthenticatedApp />} />
@@ -124,6 +127,7 @@ function App() {
             explorer={voyager}
             provider={provider}
           >
+            <NativeNotificationBridge />
             <DeployGate />
           </StarknetConfig>
         </QueryClientProvider>

--- a/client/src/components/containers/index.ts
+++ b/client/src/components/containers/index.ts
@@ -11,6 +11,8 @@ export * from "./uses";
 export * from "./game-over";
 export * from "./banners";
 export * from "./games";
+export * from "./native-notification-bridge";
+export * from "./notification-events";
 export * from "./governance-results";
 export * from "./governance-proposals";
 export * from "./governance-votes";

--- a/client/src/components/containers/native-notification-bridge.tsx
+++ b/client/src/components/containers/native-notification-bridge.tsx
@@ -1,0 +1,42 @@
+import { useAccount, useConnect } from "@starknet-react/core";
+import { useEffect, useRef } from "react";
+
+type NativeMessageHandler = {
+  postMessage: (message: unknown) => void;
+};
+
+type NativeNotificationWindow = Window & {
+  webkit?: {
+    messageHandlers?: Record<string, NativeMessageHandler | undefined>;
+  };
+};
+
+export function NativeNotificationBridge() {
+  const { account, address, isConnected } = useAccount();
+  const { connector } = useConnect();
+  const lastPostedKey = useRef("");
+
+  useEffect(() => {
+    const connectedAddress = address || account?.address;
+    if (!isConnected || !connectedAddress) {
+      lastPostedKey.current = "";
+      return;
+    }
+
+    const postKey = `${connector?.id || "unknown"}:${connectedAddress}`;
+    if (lastPostedKey.current === postKey) return;
+
+    const handler = (window as NativeNotificationWindow).webkit
+      ?.messageHandlers?.["notification-session-ready"];
+    if (!handler) return;
+
+    handler.postMessage({
+      source: "starknet-react",
+      address: connectedAddress,
+      connectorId: connector?.id || "",
+    });
+    lastPostedKey.current = postKey;
+  }, [account?.address, address, connector?.id, isConnected]);
+
+  return null;
+}

--- a/client/src/components/containers/notification-events.test.tsx
+++ b/client/src/components/containers/notification-events.test.tsx
@@ -1,0 +1,81 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  NotificationEvents,
+  notificationDeeplink,
+  notificationDeeplinkToPath,
+  notificationKind,
+} from "./notification-events";
+
+const navigate = vi.hoisted(() => vi.fn());
+
+vi.mock("react-router-dom", async () => {
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom",
+    );
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+describe("NotificationEvents", () => {
+  const origin = "https://mobile.nums.gg";
+
+  beforeEach(() => {
+    navigate.mockReset();
+  });
+
+  it("uses path deeplinks directly", () => {
+    expect(notificationDeeplinkToPath("/game/0x123?turn=4", origin)).toBe(
+      "/game/0x123?turn=4",
+    );
+  });
+
+  it("uses same-origin web URLs as internal paths", () => {
+    expect(
+      notificationDeeplinkToPath("https://mobile.nums.gg/game/7", origin),
+    ).toBe("/game/7");
+  });
+
+  it("converts nums app scheme URLs to internal paths", () => {
+    expect(
+      notificationDeeplinkToPath("nums://game/0xabc?tab=score", origin),
+    ).toBe("/game/0xabc?tab=score");
+    expect(notificationDeeplinkToPath("nums:///practice", origin)).toBe(
+      "/practice",
+    );
+  });
+
+  it("rejects external URLs", () => {
+    expect(
+      notificationDeeplinkToPath("https://example.com/game/0x123", origin),
+    ).toBeUndefined();
+    expect(
+      notificationDeeplinkToPath("//example.com/game/0x123", origin),
+    ).toBeUndefined();
+  });
+
+  it("reads deeplink aliases and kind metadata from payloads", () => {
+    expect(notificationDeeplink({ deepLink: "/game/7" }, origin)).toBe(
+      "/game/7",
+    );
+    expect(notificationDeeplink({ url: "/practice" }, origin)).toBe(
+      "/practice",
+    );
+    expect(notificationKind({ kind: " game-ready " })).toBe("game-ready");
+  });
+
+  it("handles notification click events", async () => {
+    render(<NotificationEvents />);
+
+    window.dispatchEvent(
+      new CustomEvent("push-notification-click", {
+        detail: { deeplink: "/game/new", kind: "deeplink" },
+      }),
+    );
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith("/game/new"));
+  });
+});

--- a/client/src/components/containers/notification-events.tsx
+++ b/client/src/components/containers/notification-events.tsx
@@ -1,0 +1,96 @@
+import { useCallback, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+type NativeNotificationPayload = {
+  deeplink?: unknown;
+  deepLink?: unknown;
+  url?: unknown;
+  kind?: unknown;
+};
+
+const notificationPayload = (payload: unknown): NativeNotificationPayload => {
+  if (!payload || typeof payload !== "object") return {};
+  return payload as NativeNotificationPayload;
+};
+
+export const notificationKind = (payload: unknown): string | undefined => {
+  const { kind } = notificationPayload(payload);
+  return typeof kind === "string" && kind.trim() ? kind.trim() : undefined;
+};
+
+export const notificationDeeplinkToPath = (
+  deeplink: unknown,
+  origin = globalThis.location?.origin,
+): string | undefined => {
+  if (typeof deeplink !== "string") return undefined;
+
+  const rawDeeplink = deeplink.trim();
+  if (!rawDeeplink) return undefined;
+
+  if (rawDeeplink.startsWith("/")) {
+    if (rawDeeplink.startsWith("//")) return undefined;
+    return rawDeeplink;
+  }
+
+  if (!origin) return undefined;
+
+  try {
+    const url = new URL(rawDeeplink, origin);
+
+    if (url.protocol === "nums:") {
+      const hostPath = url.host ? `/${url.host}` : "";
+      return `${hostPath}${url.pathname}${url.search}${url.hash}`;
+    }
+
+    if (
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      url.origin === origin
+    ) {
+      return `${url.pathname}${url.search}${url.hash}`;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+};
+
+export const notificationDeeplink = (
+  payload: unknown,
+  origin?: string,
+): string | undefined => {
+  const { deeplink, deepLink, url } = notificationPayload(payload);
+  return notificationDeeplinkToPath(deeplink ?? deepLink ?? url, origin);
+};
+
+export function NotificationEvents() {
+  const navigate = useNavigate();
+  const handleNotificationClick = useCallback(
+    (detail: unknown) => {
+      const path = notificationDeeplink(detail);
+
+      if (!path) return;
+
+      navigate(path);
+    },
+    [navigate],
+  );
+
+  useEffect(() => {
+    const onNotificationClick = (event: Event) => {
+      const detail = (event as CustomEvent<unknown>).detail;
+      handleNotificationClick(detail);
+    };
+
+    window.addEventListener("push-notification-click", onNotificationClick);
+
+    return () => {
+      window.removeEventListener(
+        "push-notification-click",
+        onNotificationClick,
+      );
+    };
+  }, [handleNotificationClick]);
+
+  return null;
+}

--- a/ios/Nums WebApp/AppDelegate.swift
+++ b/ios/Nums WebApp/AppDelegate.swift
@@ -52,10 +52,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         print("Unable to register for remote notifications: \(error.localizedDescription)")
       }
 
-      // This function is added here only for debugging purposes.
-//      func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-//        print("APNs token retrieved: \(deviceToken)")
-//      }
+      func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        setAPNSToken(deviceToken)
+      }
     }
 
     // [START ios_10_message_handling]

--- a/ios/Nums WebApp/PushNotifications.swift
+++ b/ios/Nums WebApp/PushNotifications.swift
@@ -1,4 +1,21 @@
+import UIKit
+import UserNotifications
 import WebKit
+
+private let notificationAppID = "nums"
+private let notificationAPIURL: URL = {
+    if let value = Bundle.main.object(forInfoDictionaryKey: "NotificationAPIURL") as? String,
+       let url = URL(string: value) {
+        return url
+    }
+    return URL(string: "https://api.cartridge.gg/query")!
+}()
+private let notificationDeviceIDDefaultsKey = "nums.notificationDeviceID"
+
+private var apnsDeviceToken: String?
+private var notificationRegistrationInFlight = false
+private var notificationRegistrationQueued = false
+private var notificationSessionReadyHandled = false
 
 class SubscribeMessage {
     var topic  = ""
@@ -132,7 +149,7 @@ func handlePushState() {
 func checkViewAndEvaluate(event: String, detail: String) {
     if let webView = currentAppWebView(), !webView.isHidden && !webView.isLoading {
         DispatchQueue.main.async(execute: {
-            webView.evaluateJavaScript("this.dispatchEvent(new CustomEvent('\(event)', { detail: \(detail) }))")
+            webView.evaluateJavaScript("window.dispatchEvent(new CustomEvent(\(jsonStringLiteral(event)), { detail: \(detail) }))")
         })
     }
     else {
@@ -142,11 +159,254 @@ func checkViewAndEvaluate(event: String, detail: String) {
     }
 }
 
-func handleFCMToken(){
+func handlePushTokenRequest(){
     DispatchQueue.main.async(execute: {
-        print("FCM token requested, but Firebase is not configured.")
+        if let token = apnsDeviceToken {
+            checkViewAndEvaluate(event: "push-token", detail: jsonStringLiteral(token))
+            registerNotificationDeviceIfPossible()
+            return
+        }
+
+        UIApplication.shared.registerForRemoteNotifications()
         checkViewAndEvaluate(event: "push-token", detail: "null")
     })
+}
+
+func handleNotificationSessionReady() {
+    print("Notification session ready signal received")
+    if notificationSessionReadyHandled {
+        registerNotificationDeviceIfPossible()
+        return
+    }
+    notificationSessionReadyHandled = true
+
+    UNUserNotificationCenter.current().getNotificationSettings { settings in
+        print("Notification authorization status: \(settings.authorizationStatus.rawValue)")
+        switch settings.authorizationStatus {
+        case .notDetermined:
+            let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+            UNUserNotificationCenter.current().requestAuthorization(options: authOptions) { granted, error in
+                if let error = error {
+                    print("Notification authorization failed: \(error.localizedDescription)")
+                }
+                guard granted else {
+                    print("Notification authorization was not granted")
+                    return
+                }
+                DispatchQueue.main.async {
+                    UIApplication.shared.registerForRemoteNotifications()
+                }
+            }
+        case .authorized, .ephemeral, .provisional:
+            DispatchQueue.main.async {
+                UIApplication.shared.registerForRemoteNotifications()
+                registerNotificationDeviceIfPossible()
+            }
+        case .denied:
+            print("Notification authorization denied in Settings")
+            return
+        @unknown default:
+            print("Notification authorization status is unknown")
+            return
+        }
+    }
+}
+
+func setAPNSToken(_ deviceToken: Data) {
+    apnsDeviceToken = deviceToken.map { String(format: "%02x", $0) }.joined()
+    print("APNs token received")
+    registerNotificationDeviceIfPossible()
+
+    if let token = apnsDeviceToken {
+        checkViewAndEvaluate(event: "push-token", detail: jsonStringLiteral(token))
+    }
+}
+
+func disableRegisteredNotificationDevice(completion: (() -> Void)? = nil) {
+    guard let deviceID = UserDefaults.standard.string(forKey: notificationDeviceIDDefaultsKey), !deviceID.isEmpty else {
+        completion?()
+        return
+    }
+
+    performNotificationGraphQLRequest(
+        query: """
+        mutation DisableNotificationDevice($id: ID!) {
+          disableNotificationDevice(id: $id)
+        }
+        """,
+        variables: ["id": deviceID]
+    ) { _, error in
+        if let error = error {
+            print("Failed to disable notification device: \(error.localizedDescription)")
+        }
+        UserDefaults.standard.removeObject(forKey: notificationDeviceIDDefaultsKey)
+        completion?()
+    }
+}
+
+private func registerNotificationDeviceIfPossible() {
+    guard let token = apnsDeviceToken, !token.isEmpty else {
+        print("Notification registration waiting for APNs token")
+        return
+    }
+    guard isValidAPNSToken(token) else {
+        print("Notification registration skipped: invalid APNs token")
+        return
+    }
+
+    if notificationRegistrationInFlight {
+        notificationRegistrationQueued = true
+        return
+    }
+
+    notificationRegistrationInFlight = true
+    print("Registering notification device with APNs provider")
+    performNotificationGraphQLRequest(
+        query: """
+        mutation RegisterNotificationDevice($input: RegisterNotificationDeviceInput!) {
+          registerNotificationDevice(input: $input) {
+            id
+          }
+        }
+        """,
+        variables: [
+            "input": [
+                "appId": notificationAppID,
+                "platform": "IOS",
+                "provider": "APNS",
+                "token": token,
+            ],
+        ]
+    ) { json, error in
+        notificationRegistrationInFlight = false
+
+        if let error = error {
+            print("Failed to register notification device: \(error.localizedDescription)")
+        } else if let deviceID = notificationDeviceID(from: json) {
+            UserDefaults.standard.set(deviceID, forKey: notificationDeviceIDDefaultsKey)
+            print("Registered notification device: \(deviceID)")
+        }
+
+        if notificationRegistrationQueued {
+            notificationRegistrationQueued = false
+            registerNotificationDeviceIfPossible()
+        }
+    }
+}
+
+private func performNotificationGraphQLRequest(
+    query: String,
+    variables: [String: Any],
+    completion: @escaping ([String: Any]?, Error?) -> Void
+) {
+    WKWebsiteDataStore.default().httpCookieStore.getAllCookies { cookies in
+        var request = URLRequest(url: notificationAPIURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let matchingCookies = cookiesForNotificationAPI(cookies)
+        print("Notification API cookies matched: \(matchingCookies.count)")
+        if !matchingCookies.isEmpty,
+           let cookieHeader = HTTPCookie.requestHeaderFields(with: matchingCookies)["Cookie"] {
+            request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        }
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: [
+                "query": query,
+                "variables": variables,
+            ])
+        } catch {
+            DispatchQueue.main.async { completion(nil, error) }
+            return
+        }
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                DispatchQueue.main.async { completion(nil, error) }
+                return
+            }
+
+            if let httpResponse = response as? HTTPURLResponse,
+               !(200..<300).contains(httpResponse.statusCode) {
+                let error = NSError(
+                    domain: "NumsNotifications",
+                    code: httpResponse.statusCode,
+                    userInfo: [NSLocalizedDescriptionKey: "Notification API returned HTTP \(httpResponse.statusCode)"]
+                )
+                DispatchQueue.main.async { completion(nil, error) }
+                return
+            }
+
+            guard let data = data else {
+                let error = NSError(
+                    domain: "NumsNotifications",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "Notification API returned an empty response"]
+                )
+                DispatchQueue.main.async { completion(nil, error) }
+                return
+            }
+
+            do {
+                let decoded = try JSONSerialization.jsonObject(with: data)
+                guard let json = decoded as? [String: Any] else {
+                    throw NSError(
+                        domain: "NumsNotifications",
+                        code: -2,
+                        userInfo: [NSLocalizedDescriptionKey: "Notification API returned an invalid response"]
+                    )
+                }
+
+                if let errors = json["errors"] as? [[String: Any]], !errors.isEmpty {
+                    let message = (errors.first?["message"] as? String) ?? "Notification API request failed"
+                    throw NSError(
+                        domain: "NumsNotifications",
+                        code: -3,
+                        userInfo: [NSLocalizedDescriptionKey: message]
+                    )
+                }
+
+                DispatchQueue.main.async { completion(json, nil) }
+            } catch {
+                DispatchQueue.main.async { completion(nil, error) }
+            }
+        }.resume()
+    }
+}
+
+private func cookiesForNotificationAPI(_ cookies: [HTTPCookie]) -> [HTTPCookie] {
+    guard let host = notificationAPIURL.host?.lowercased() else { return [] }
+    return cookies.filter { cookie in
+        let domain = cookie.domain.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "."))
+        return host == domain || host.hasSuffix(".\(domain)")
+    }
+}
+
+private func notificationDeviceID(from json: [String: Any]?) -> String? {
+    guard
+        let data = json?["data"] as? [String: Any],
+        let device = data["registerNotificationDevice"] as? [String: Any],
+        let id = device["id"] as? String
+    else {
+        return nil
+    }
+    return id
+}
+
+private func isValidAPNSToken(_ token: String) -> Bool {
+    token.range(of: #"^[0-9a-f]{64}$"#, options: .regularExpression) != nil
+}
+
+private func jsonStringLiteral(_ value: String) -> String {
+    guard
+        let data = try? JSONEncoder().encode(value),
+        let string = String(data: data, encoding: .utf8)
+    else {
+        return "null"
+    }
+    return string
 }
 
 func sendPushToWebView(userInfo: [AnyHashable: Any]){

--- a/ios/Nums WebApp/ViewController.swift
+++ b/ios/Nums WebApp/ViewController.swift
@@ -252,6 +252,7 @@ class ViewController: UIViewController, WKNavigationDelegate, UIDocumentInteract
             self.loadingView.isHidden = true
 
             self.overrideUIStyle()
+            triggerNotificationRegistrationCheck(in: webView)
             if iframeStorageDebugEnabled {
                 appWebView.evaluateJavaScript("window.__showIframeStorageDebugPanel && window.__showIframeStorageDebugPanel();", completionHandler: nil)
             }
@@ -524,10 +525,16 @@ extension ViewController: WKScriptMessageHandler {
             handlePushState()
         }
         if message.name == "push-token" {
-            handleFCMToken()
+            handlePushTokenRequest()
+        }
+        if message.name == "notification-session-ready" {
+            print("Notification session ready message received from web")
+            handleNotificationSessionReady()
         }
         if message.name == "cartridge-logout-cleanup" {
-            clearCartridgeWebsiteData()
+            disableRegisteredNotificationDevice {
+                clearCartridgeWebsiteData()
+            }
         }
   }
 }

--- a/ios/Nums WebApp/WebView.swift
+++ b/ios/Nums WebApp/WebView.swift
@@ -6,6 +6,102 @@ import SafariServices
 let iframeStorageSnapshotKeyPrefix = "__iframeStorageSnapshot__:"
 let iframeStorageTargetHost = "x.cartridge.gg"
 
+func triggerNotificationRegistrationCheck(in webView: WKWebView) {
+    let script = """
+    (function() {
+      var targetHost = "\(iframeStorageTargetHost)";
+      var keyPrefix = "\(iframeStorageSnapshotKeyPrefix)";
+      var hasOwn = function(obj, key) {
+        return Object.prototype.hasOwnProperty.call(obj, key);
+      };
+      var safeJsonParse = function(value) {
+        if (typeof value !== "string" || value.length === 0) return null;
+        try {
+          return JSON.parse(value);
+        } catch (_) {
+          return null;
+        }
+      };
+      var parseSessionExpirySeconds = function(rawSessionValue) {
+        var parsed = safeJsonParse(rawSessionValue);
+        var expiresAt = parsed &&
+          parsed.Session &&
+          parsed.Session.session &&
+          parsed.Session.session.inner &&
+          parsed.Session.session.inner.expires_at;
+        if (typeof expiresAt !== "string" || expiresAt.length === 0) return null;
+        var value = /^0x[0-9a-f]+$/i.test(expiresAt) ? parseInt(expiresAt, 16) : parseInt(expiresAt, 10);
+        return Number.isFinite(value) ? value : null;
+      };
+      var hasValidActiveSession = function(snapshot) {
+        var activeKey = "@cartridge/active";
+        if (!snapshot || typeof snapshot !== "object" || !hasOwn(snapshot, activeKey)) return false;
+
+        var parsedActive = safeJsonParse(snapshot[activeKey]);
+        var activeData = parsedActive && parsedActive.Active ? parsedActive.Active : null;
+        var activeAddress = activeData && typeof activeData.address === "string" ? activeData.address.toLowerCase() : "";
+        var activeChainId = activeData && typeof activeData.chain_id === "string" ? activeData.chain_id.toLowerCase() : "";
+        if (!activeAddress || !activeChainId) return false;
+
+        var accountKey = "@cartridge/account/" + activeAddress + "/" + activeChainId;
+        var sessionKey = "@cartridge/session/" + activeAddress + "/" + activeChainId;
+        if (!hasOwn(snapshot, accountKey) || !hasOwn(snapshot, sessionKey)) return false;
+
+        var expiresAt = parseSessionExpirySeconds(snapshot[sessionKey]);
+        return !(typeof expiresAt === "number" && expiresAt <= Math.floor(Date.now() / 1000));
+      };
+      var isManagedTopStorageKey = function(key) {
+        return typeof key === "string" &&
+          (key.indexOf("@cartridge/") === 0 || key === "needs_session_creation" || key === "last_pending_block_tx");
+      };
+      var readTopStorageSnapshot = function() {
+        var snapshot = {};
+        try {
+          for (var i = 0; i < localStorage.length; i += 1) {
+            var key = localStorage.key(i);
+            if (!isManagedTopStorageKey(key)) continue;
+            var value = localStorage.getItem(key);
+            if (typeof value === "string") {
+              snapshot[key] = value;
+            }
+          }
+        } catch (_) {}
+        return snapshot;
+      };
+      var readStoredSnapshot = function() {
+        try {
+          var raw = localStorage.getItem(keyPrefix + targetHost);
+          var parsed = raw ? JSON.parse(raw) : null;
+          return parsed && typeof parsed === "object" ? parsed : {};
+        } catch (_) {
+          return {};
+        }
+      };
+      var authenticated = hasValidActiveSession(readTopStorageSnapshot()) || hasValidActiveSession(readStoredSnapshot());
+      if (authenticated) {
+        try {
+          var handlers = window.webkit && window.webkit.messageHandlers;
+          var handler = handlers && handlers["notification-session-ready"];
+          if (handler && typeof handler.postMessage === "function") {
+            handler.postMessage({ source: "native-session-check" });
+          }
+        } catch (_) {}
+      }
+      return authenticated;
+    })();
+    """
+
+    webView.evaluateJavaScript(script) { result, error in
+        if let error = error {
+            print("Notification session check failed: \(error.localizedDescription)")
+            return
+        }
+        if let authenticated = result as? Bool {
+            print("Notification session check authenticated: \(authenticated)")
+        }
+    }
+}
+
 func createWebView(container: UIView, WKSMH: WKScriptMessageHandler, WKND: WKNavigationDelegate) -> WKWebView{
 
     let config = WKWebViewConfiguration()
@@ -18,6 +114,7 @@ func createWebView(container: UIView, WKSMH: WKScriptMessageHandler, WKND: WKNav
     userContentController.add(WKSMH, name: "push-permission-request")
     userContentController.add(WKSMH, name: "push-permission-state")
     userContentController.add(WKSMH, name: "push-token")
+    userContentController.add(WKSMH, name: "notification-session-ready")
     if enableCartridgeIframeStorageRelay {
         userContentController.add(WKSMH, name: "cartridge-logout-cleanup")
     }


### PR DESCRIPTION
Adds iOS APNs registration for the Nums app and registers devices through the Cartridge notification API. Wires the web bridge so Controller-authenticated sessions trigger native registration, handles logout cleanup, and supports notification tap deeplinks in the React app. Includes focused deeplink tests plus client test, typecheck, and build validation.