### PR TITLE
Add PostHog TikTok attribution tracking

### DIFF
--- a/client/src/context/posthog.tsx
+++ b/client/src/context/posthog.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import PostHog from "posthog-js-lite";
 import { resolveAttribution } from "@/lib/attribution";
-import { loadTikTokPixel } from "@/lib/tiktok-pixel";
+import { loadTikTokPixel, NUMS_TIKTOK_PIXEL_ID } from "@/lib/tiktok-pixel";
 
 type JsonValue =
   | string
@@ -45,7 +45,8 @@ export const PostHogProvider = ({ children }: PostHogProviderProps) => {
     const isLocalhost =
       typeof window !== "undefined" &&
       window.location.hostname.includes("localhost");
-    const pixelId = import.meta.env.VITE_TIKTOK_PIXEL_ID;
+    const pixelId =
+      import.meta.env.VITE_TIKTOK_PIXEL_ID || NUMS_TIKTOK_PIXEL_ID;
     if (!isLocalhost && pixelId) {
       loadTikTokPixel(pixelId);
     }

--- a/client/src/context/posthog.tsx
+++ b/client/src/context/posthog.tsx
@@ -7,6 +7,8 @@ import {
   type ReactNode,
 } from "react";
 import PostHog from "posthog-js-lite";
+import { resolveAttribution } from "@/lib/attribution";
+import { loadTikTokPixel } from "@/lib/tiktok-pixel";
 
 type JsonValue =
   | string
@@ -37,22 +39,42 @@ interface PostHogProviderProps {
 
 export const PostHogProvider = ({ children }: PostHogProviderProps) => {
   const clientRef = useRef<PostHog | null>(null);
+  const attributionRef = useRef<ReturnType<typeof resolveAttribution>>(null);
 
   useEffect(() => {
+    const isLocalhost =
+      typeof window !== "undefined" &&
+      window.location.hostname.includes("localhost");
+    const pixelId = import.meta.env.VITE_TIKTOK_PIXEL_ID;
+    if (!isLocalhost && pixelId) {
+      loadTikTokPixel(pixelId);
+    }
+
     const key = import.meta.env.VITE_POSTHOG_KEY;
-    if (
-      !key ||
-      (typeof window !== "undefined" &&
-        window.location.hostname.includes("localhost"))
-    ) {
+    if (!key || isLocalhost) {
       return;
     }
 
     const host = import.meta.env.VITE_POSTHOG_HOST || "/ingest";
-    clientRef.current = new PostHog(key, {
+    const client = new PostHog(key, {
       host,
       persistence: "localStorage",
+      captureHistoryEvents: true,
     });
+    clientRef.current = client;
+
+    try {
+      attributionRef.current = resolveAttribution({
+        location: window.location,
+        referrer: window.document.referrer,
+        storage: window.localStorage,
+      });
+      if (attributionRef.current) {
+        client.register(attributionRef.current.eventProperties);
+      }
+    } catch (e) {
+      console.error("[posthog] attribution setup failed", e);
+    }
 
     return () => {
       clientRef.current = null;
@@ -73,7 +95,32 @@ export const PostHogProvider = ({ children }: PostHogProviderProps) => {
         properties?: Record<string, JsonValue>,
       ) => {
         try {
-          clientRef.current?.identify(distinctId, properties);
+          const attribution = attributionRef.current;
+          const existingSet = properties?.$set as
+            | Record<string, JsonValue>
+            | undefined;
+          const plainSet = Object.fromEntries(
+            Object.entries(properties ?? {}).filter(
+              ([key]) => !key.startsWith("$"),
+            ),
+          ) as Record<string, JsonValue>;
+          clientRef.current?.identify(
+            distinctId,
+            attribution
+              ? {
+                  ...properties,
+                  $set: {
+                    ...(existingSet ?? plainSet),
+                    ...attribution.setProperties,
+                  },
+                  $set_once: {
+                    ...((properties?.$set_once as Record<string, JsonValue>) ??
+                      {}),
+                    ...attribution.setOnceProperties,
+                  },
+                }
+              : properties,
+          );
         } catch (e) {
           console.error("[posthog] identify failed", e);
         }

--- a/client/src/hooks/banner.ts
+++ b/client/src/hooks/banner.ts
@@ -10,6 +10,12 @@ import type ControllerConnector from "@cartridge/connector/controller";
 import { getSetupAddress } from "@/config";
 import { usePreserveSearchNavigate } from "@/lib/router";
 import { useControllers } from "@/context/controllers";
+import { usePostHog } from "@/context/posthog";
+import { usePrices } from "@/context/prices";
+import {
+  bundleStarterpackEventProperties,
+  createAnalyticsEventId,
+} from "@/lib/analytics";
 
 export interface GameBanner {
   preset: string;
@@ -54,11 +60,13 @@ const BANNERS: GameBanner[] = [
 export const useBanners = () => {
   const { account, connector } = useAccount();
   const { chain } = useNetwork();
-  const { issuances } = useBundles();
+  const { bundles, issuances } = useBundles();
+  const { getNumsPrice } = usePrices();
   const [results, setResults] = useState<BannerConfig[]>([]);
   const [loading, setLoading] = useState(true);
   const navigate = usePreserveSearchNavigate();
   const { find } = useControllers();
+  const { capture } = usePostHog();
 
   const username = useMemo(() => {
     if (!account?.address) return undefined;
@@ -73,7 +81,35 @@ export const useBanners = () => {
 
   const handleShare = useCallback(async () => {
     if (!username || !chain) return;
+    const bundle = bundles.find((item) => item.id === 0);
+    const numsPriceUsd = parseFloat(getNumsPrice() || "0.0");
+    const checkoutEventId = createAnalyticsEventId("starterpack_checkout");
+
+    if (bundle) {
+      capture(
+        "starterpack_checkout_started",
+        bundleStarterpackEventProperties({
+          eventId: checkoutEventId,
+          bundle,
+          numsPriceUsd,
+        }),
+      );
+    }
+
     const onPurchaseComplete = () => {
+      if (bundle) {
+        capture(
+          "starterpack_purchased",
+          bundleStarterpackEventProperties({
+            eventId: checkoutEventId.replace(
+              "starterpack_checkout",
+              "starterpack_purchase",
+            ),
+            bundle,
+            numsPriceUsd,
+          }),
+        );
+      }
       navigate("/game");
     };
 
@@ -87,7 +123,7 @@ export const useBanners = () => {
       onPurchaseComplete,
       socialClaimOptions,
     });
-  }, [navigate, chain.id, username, referralLink]);
+  }, [navigate, chain, username, referralLink, bundles, getNumsPrice, capture]);
 
   useEffect(() => {
     const load = async () => {

--- a/client/src/lib/analytics.ts
+++ b/client/src/lib/analytics.ts
@@ -1,0 +1,81 @@
+import type { Bundle, Starterpack } from "@/models";
+
+type StarterpackLike = Pick<Starterpack, "id" | "price" | "multiplier">;
+type BundleLike = Pick<Bundle, "id" | "price">;
+
+const STARTERPACK_NAME = "NUMS Starterpack";
+
+const toUsdValue = (
+  numsAmount: number,
+  numsPriceUsd: number,
+): number | null => {
+  if (!Number.isFinite(numsAmount) || !Number.isFinite(numsPriceUsd))
+    return null;
+  return Number((numsAmount * numsPriceUsd).toFixed(2));
+};
+
+export const createAnalyticsEventId = (prefix: string): string => {
+  const random =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+
+  return `${prefix}:${Date.now()}:${random}`;
+};
+
+export const starterpackEventProperties = ({
+  eventId,
+  starterpack,
+  numsPriceUsd,
+}: {
+  eventId: string;
+  starterpack: StarterpackLike;
+  numsPriceUsd: number;
+}) => {
+  const starterpackPriceNums = Number(starterpack.price) / 10 ** 6;
+  const value = toUsdValue(starterpackPriceNums, numsPriceUsd);
+
+  return {
+    event_id: eventId,
+    sku: `nums-starterpack-${starterpack.id}`,
+    name: STARTERPACK_NAME,
+    brand: "NUMS",
+    category: "starterpack",
+    content_type: "product",
+    quantity: 1,
+    currency: "USD",
+    starterpack_id: starterpack.id,
+    starterpack_price_nums: starterpackPriceNums,
+    nums_price_usd: numsPriceUsd,
+    multiplier: starterpack.multiplier,
+    ...(value !== null ? { value, price: value } : {}),
+  };
+};
+
+export const bundleStarterpackEventProperties = ({
+  eventId,
+  bundle,
+  numsPriceUsd,
+}: {
+  eventId: string;
+  bundle: BundleLike;
+  numsPriceUsd: number;
+}) => {
+  const starterpackPriceNums = Number(bundle.price) / 10 ** 6;
+  const value = toUsdValue(starterpackPriceNums, numsPriceUsd);
+
+  return {
+    event_id: eventId,
+    sku: `nums-starterpack-${bundle.id}`,
+    name: STARTERPACK_NAME,
+    brand: "NUMS",
+    category: "starterpack",
+    content_type: "product",
+    quantity: 1,
+    currency: "USD",
+    starterpack_id: bundle.id,
+    starterpack_price_nums: starterpackPriceNums,
+    nums_price_usd: numsPriceUsd,
+    ...(value !== null ? { value, price: value } : {}),
+  };
+};

--- a/client/src/lib/attribution.test.ts
+++ b/client/src/lib/attribution.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { parseAttributionFields, resolveAttribution } from "@/lib/attribution";
+
+const createStorage = () => {
+  const values = new Map<string, string>();
+
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+    removeItem: (key: string) => values.delete(key),
+  };
+};
+
+const createLocation = (url: string): Location =>
+  new URL(url) as unknown as Location;
+
+describe("attribution", () => {
+  it("parses TikTok, Google, Meta, LinkedIn, Microsoft, and UTM params", () => {
+    expect(
+      parseAttributionFields(
+        "?ttclid=tt&utm_source=tiktok&utm_medium=paid&utm_campaign=launch&utm_content=ad&utm_term=nums&gclid=g&gbraid=gb&wbraid=wb&fbclid=fb&msclkid=ms&li_fat_id=li&ignored=1",
+      ),
+    ).toEqual({
+      ttclid: "tt",
+      utm_source: "tiktok",
+      utm_medium: "paid",
+      utm_campaign: "launch",
+      utm_content: "ad",
+      utm_term: "nums",
+      gclid: "g",
+      gbraid: "gb",
+      wbraid: "wb",
+      fbclid: "fb",
+      msclkid: "ms",
+      li_fat_id: "li",
+    });
+  });
+
+  it("stores first-touch and latest-touch attribution", () => {
+    const storage = createStorage();
+    const first = resolveAttribution({
+      location: createLocation(
+        "https://nums.gg/?ttclid=first&utm_source=tiktok&utm_campaign=alpha",
+      ),
+      referrer: "https://www.tiktok.com/",
+      storage,
+      now: Date.UTC(2026, 4, 1),
+    });
+
+    const latest = resolveAttribution({
+      location: createLocation(
+        "https://nums.gg/game?ttclid=latest&utm_source=tiktok&utm_campaign=beta",
+      ),
+      referrer: "",
+      storage,
+      now: Date.UTC(2026, 4, 2),
+    });
+
+    expect(first?.eventProperties.ttclid).toBe("first");
+    expect(first?.setOnceProperties.$initial_ttclid).toBe("first");
+    expect(latest?.eventProperties.ttclid).toBe("latest");
+    expect(latest?.setProperties.utm_campaign).toBe("beta");
+    expect(latest?.setOnceProperties.$initial_ttclid).toBe("first");
+    expect(latest?.setOnceProperties.$initial_utm_campaign).toBe("alpha");
+  });
+
+  it("reuses unexpired stored attribution when the URL has no ad params", () => {
+    const storage = createStorage();
+    resolveAttribution({
+      location: createLocation("https://nums.gg/?ttclid=first"),
+      referrer: "",
+      storage,
+      now: Date.UTC(2026, 4, 1),
+    });
+
+    const attribution = resolveAttribution({
+      location: createLocation("https://nums.gg/game"),
+      referrer: "",
+      storage,
+      now: Date.UTC(2026, 4, 2),
+    });
+
+    expect(attribution?.eventProperties.ttclid).toBe("first");
+    expect(attribution?.setOnceProperties.$initial_ttclid).toBe("first");
+  });
+
+  it("drops expired stored attribution", () => {
+    const storage = createStorage();
+    resolveAttribution({
+      location: createLocation("https://nums.gg/?ttclid=first"),
+      referrer: "",
+      storage,
+      now: Date.UTC(2026, 4, 1),
+      ttlMs: 1000,
+    });
+
+    const attribution = resolveAttribution({
+      location: createLocation("https://nums.gg/game"),
+      referrer: "",
+      storage,
+      now: Date.UTC(2026, 4, 1) + 1001,
+      ttlMs: 1000,
+    });
+
+    expect(attribution).toBeNull();
+  });
+});

--- a/client/src/lib/attribution.ts
+++ b/client/src/lib/attribution.ts
@@ -1,0 +1,154 @@
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export type AttributionFields = Record<string, string>;
+
+export interface AttributionSnapshot {
+  fields: AttributionFields;
+  landing_url: string;
+  landing_path: string;
+  referrer: string;
+  captured_at: string;
+}
+
+interface StoredAttribution {
+  first: AttributionSnapshot;
+  latest: AttributionSnapshot;
+  expires_at: number;
+}
+
+export interface AttributionProperties {
+  eventProperties: Record<string, string>;
+  setProperties: Record<string, string>;
+  setOnceProperties: Record<string, string>;
+}
+
+const STORAGE_KEY = "nums:attribution:v1";
+const DEFAULT_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+const TRACKED_PARAMS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+  "ttclid",
+  "gclid",
+  "gbraid",
+  "wbraid",
+  "fbclid",
+  "msclkid",
+  "li_fat_id",
+] as const;
+
+const snapshotProperties = (
+  snapshot: AttributionSnapshot,
+): Record<string, string> => ({
+  ...snapshot.fields,
+  landing_url: snapshot.landing_url,
+  landing_path: snapshot.landing_path,
+  referrer: snapshot.referrer,
+  attribution_captured_at: snapshot.captured_at,
+});
+
+const initialProperties = (
+  snapshot: AttributionSnapshot,
+): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(snapshotProperties(snapshot)).map(([key, value]) => [
+      `$initial_${key}`,
+      value,
+    ]),
+  );
+
+const readStoredAttribution = (
+  storage: StorageLike,
+  now: number,
+): StoredAttribution | null => {
+  const raw = storage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as StoredAttribution;
+    if (!parsed.first || !parsed.latest || parsed.expires_at <= now) {
+      storage.removeItem(STORAGE_KEY);
+      return null;
+    }
+    return parsed;
+  } catch (_error) {
+    storage.removeItem(STORAGE_KEY);
+    return null;
+  }
+};
+
+export const parseAttributionFields = (search: string): AttributionFields => {
+  const params = new URLSearchParams(search);
+  const fields: AttributionFields = {};
+
+  for (const key of TRACKED_PARAMS) {
+    const value = params.get(key);
+    if (value) fields[key] = value;
+  }
+
+  return fields;
+};
+
+export const buildAttributionSnapshot = (
+  location: Location,
+  referrer: string,
+  now: number,
+): AttributionSnapshot | null => {
+  const fields = parseAttributionFields(location.search);
+  if (Object.keys(fields).length === 0) return null;
+
+  return {
+    fields,
+    landing_url: location.href,
+    landing_path: `${location.pathname}${location.search}${location.hash}`,
+    referrer,
+    captured_at: new Date(now).toISOString(),
+  };
+};
+
+export const resolveAttribution = ({
+  location,
+  referrer,
+  storage,
+  now = Date.now(),
+  ttlMs = DEFAULT_TTL_MS,
+}: {
+  location: Location;
+  referrer: string;
+  storage: StorageLike;
+  now?: number;
+  ttlMs?: number;
+}): AttributionProperties | null => {
+  const stored = readStoredAttribution(storage, now);
+  const landingSnapshot = buildAttributionSnapshot(location, referrer, now);
+
+  const attribution =
+    landingSnapshot !== null
+      ? {
+          first: stored?.first ?? landingSnapshot,
+          latest: landingSnapshot,
+          expires_at: now + ttlMs,
+        }
+      : stored;
+
+  if (!attribution) return null;
+
+  if (landingSnapshot !== null) {
+    storage.setItem(STORAGE_KEY, JSON.stringify(attribution));
+  }
+
+  const latest = snapshotProperties(attribution.latest);
+  const initial = initialProperties(attribution.first);
+
+  return {
+    eventProperties: {
+      ...latest,
+      ...initial,
+    },
+    setProperties: latest,
+    setOnceProperties: initial,
+  };
+};

--- a/client/src/lib/tiktok-pixel.ts
+++ b/client/src/lib/tiktok-pixel.ts
@@ -1,0 +1,98 @@
+type TikTokMethod =
+  | "page"
+  | "track"
+  | "identify"
+  | "instances"
+  | "debug"
+  | "on"
+  | "off"
+  | "once"
+  | "ready"
+  | "alias"
+  | "group"
+  | "enableCookie"
+  | "disableCookie"
+  | "holdConsent"
+  | "revokeConsent"
+  | "grantConsent";
+
+type TikTokQueue = unknown[] & {
+  _i?: Record<string, unknown>;
+  _o?: Record<string, unknown>;
+  _t?: Record<string, number>;
+  _u?: string;
+  methods?: TikTokMethod[];
+  setAndDefer?: (queue: TikTokQueue, method: TikTokMethod) => void;
+  load?: (pixelId: string, options?: Record<string, unknown>) => void;
+  page?: () => void;
+};
+
+declare global {
+  interface Window {
+    ttq?: TikTokQueue;
+    __numsTikTokPixelId?: string;
+  }
+}
+
+const TIKTOK_SCRIPT_BASE = "https://analytics.tiktok.com/i18n/pixel/events.js";
+
+export const loadTikTokPixel = (pixelId: string): void => {
+  if (typeof window === "undefined" || !pixelId) return;
+  if (window.__numsTikTokPixelId === pixelId) {
+    window.ttq?.page?.();
+    return;
+  }
+
+  const ttq = (window.ttq = window.ttq || ([] as unknown as TikTokQueue));
+  ttq.methods = [
+    "page",
+    "track",
+    "identify",
+    "instances",
+    "debug",
+    "on",
+    "off",
+    "once",
+    "ready",
+    "alias",
+    "group",
+    "enableCookie",
+    "disableCookie",
+    "holdConsent",
+    "revokeConsent",
+    "grantConsent",
+  ];
+  ttq.setAndDefer = (queue, method) => {
+    const deferredQueue = queue as TikTokQueue &
+      Record<TikTokMethod, (...args: unknown[]) => void>;
+    deferredQueue[method] = (...args: unknown[]) => {
+      queue.push([method, ...args]);
+    };
+  };
+
+  for (const method of ttq.methods) {
+    ttq.setAndDefer(ttq, method);
+  }
+
+  ttq.load = (id, options) => {
+    ttq._i = ttq._i || {};
+    ttq._i[id] = [];
+    ttq._t = ttq._t || {};
+    ttq._t[id] = Date.now();
+    ttq._o = ttq._o || {};
+    ttq._o[id] = options || {};
+    ttq._u = TIKTOK_SCRIPT_BASE;
+
+    const script = document.createElement("script");
+    script.type = "text/javascript";
+    script.async = true;
+    script.src = `${TIKTOK_SCRIPT_BASE}?sdkid=${id}&lib=ttq`;
+
+    const firstScript = document.getElementsByTagName("script")[0];
+    firstScript.parentNode?.insertBefore(script, firstScript);
+  };
+
+  ttq.load(pixelId);
+  ttq.page?.();
+  window.__numsTikTokPixelId = pixelId;
+};

--- a/client/src/lib/tiktok-pixel.ts
+++ b/client/src/lib/tiktok-pixel.ts
@@ -17,24 +17,27 @@ type TikTokMethod =
   | "grantConsent";
 
 type TikTokQueue = unknown[] & {
-  _i?: Record<string, unknown>;
+  _i?: Record<string, TikTokQueue>;
   _o?: Record<string, unknown>;
   _t?: Record<string, number>;
   _u?: string;
   methods?: TikTokMethod[];
   setAndDefer?: (queue: TikTokQueue, method: TikTokMethod) => void;
+  instance?: (pixelId: string) => TikTokQueue;
   load?: (pixelId: string, options?: Record<string, unknown>) => void;
   page?: () => void;
 };
 
 declare global {
   interface Window {
+    TiktokAnalyticsObject?: "ttq";
     ttq?: TikTokQueue;
     __numsTikTokPixelId?: string;
   }
 }
 
 const TIKTOK_SCRIPT_BASE = "https://analytics.tiktok.com/i18n/pixel/events.js";
+export const NUMS_TIKTOK_PIXEL_ID = "D7UE2GJC77U1G0JPP17G";
 
 export const loadTikTokPixel = (pixelId: string): void => {
   if (typeof window === "undefined" || !pixelId) return;
@@ -43,6 +46,7 @@ export const loadTikTokPixel = (pixelId: string): void => {
     return;
   }
 
+  window.TiktokAnalyticsObject = "ttq";
   const ttq = (window.ttq = window.ttq || ([] as unknown as TikTokQueue));
   ttq.methods = [
     "page",
@@ -74,14 +78,22 @@ export const loadTikTokPixel = (pixelId: string): void => {
     ttq.setAndDefer(ttq, method);
   }
 
+  ttq.instance = (id) => {
+    const instance = ttq._i?.[id] || ([] as unknown as TikTokQueue);
+    for (const method of ttq.methods ?? []) {
+      ttq.setAndDefer?.(instance, method);
+    }
+    return instance;
+  };
+
   ttq.load = (id, options) => {
     ttq._i = ttq._i || {};
-    ttq._i[id] = [];
+    ttq._i[id] = [] as unknown as TikTokQueue;
+    ttq._i[id]._u = TIKTOK_SCRIPT_BASE;
     ttq._t = ttq._t || {};
     ttq._t[id] = Date.now();
     ttq._o = ttq._o || {};
     ttq._o[id] = options || {};
-    ttq._u = TIKTOK_SCRIPT_BASE;
 
     const script = document.createElement("script");
     script.type = "text/javascript";

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,8 +1,9 @@
 import { HomeScene, LoadingScene } from "@/components/scenes";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePreserveSearchNavigate } from "@/lib/router";
 import { useGames } from "@/context/games";
 import { usePurchaseModal } from "@/context/purchase-modal";
+import { usePostHog } from "@/context/posthog";
 import { usePrices } from "@/context/prices";
 import { useEntities } from "@/context/entities";
 import { useHeader } from "@/hooks/header";
@@ -12,6 +13,10 @@ import { ChartHelper } from "@/helpers/chart";
 import { useMultiplier } from "@/hooks/multiplier";
 import { useActivities } from "@/hooks/activities";
 import { useBanners } from "@/hooks/banner";
+import {
+  createAnalyticsEventId,
+  starterpackEventProperties,
+} from "@/lib/analytics";
 
 export const Home = () => {
   const navigate = usePreserveSearchNavigate();
@@ -32,6 +37,8 @@ export const Home = () => {
   const [defaultLoading, setDefaultLoading] = useState(true);
   const [gameId, setGameId] = useState<number | undefined>(undefined);
   const { banners } = useBanners();
+  const { capture } = usePostHog();
+  const viewedStarterpackIdsRef = useRef<Set<number>>(new Set());
 
   const numsPrice = useMemo(() => {
     return parseFloat(getNumsPrice() || "0.0");
@@ -43,6 +50,22 @@ export const Home = () => {
   const playPrice = useMemo(() => {
     return Number(activeStarterpack?.price || 2_000_000n) / 10 ** 6;
   }, [activeStarterpack]);
+
+  useEffect(() => {
+    if (loading || defaultLoading) return;
+    if (!activeStarterpack) return;
+    if (viewedStarterpackIdsRef.current.has(activeStarterpack.id)) return;
+
+    viewedStarterpackIdsRef.current.add(activeStarterpack.id);
+    capture(
+      "starterpack_viewed",
+      starterpackEventProperties({
+        eventId: createAnalyticsEventId("starterpack_view"),
+        starterpack: activeStarterpack,
+        numsPriceUsd: numsPrice,
+      }),
+    );
+  }, [activeStarterpack, capture, defaultLoading, loading, numsPrice]);
 
   // Estimate multiplier from on-chain formula via real Ekubo quote
   const { multiplier } = useMultiplier({

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -50,6 +50,10 @@ import { useAirdrop } from "@/hooks/airdrop";
 import { shortAddress } from "@/helpers";
 import { usePostHog } from "@/context/posthog";
 import { getSetupAddress } from "@/config";
+import {
+  bundleStarterpackEventProperties,
+  createAnalyticsEventId,
+} from "@/lib/analytics";
 
 export { Game } from "./game";
 export { Home } from "./home";
@@ -107,6 +111,7 @@ export const Main = ({ children }: MainProps) => {
   // PostHog analytics
   const { capture, identify } = usePostHog();
   const prevAddressRef = useRef<string | undefined>(undefined);
+  const checkoutEventIdRef = useRef<string | null>(null);
 
   // Track wallet connect/disconnect and identify user
   useEffect(() => {
@@ -235,7 +240,33 @@ export const Main = ({ children }: MainProps) => {
 
   const handlePurchase = useCallback(async () => {
     if (!bundle || !chain) return;
+    const checkoutEventId = createAnalyticsEventId("starterpack_checkout");
+    checkoutEventIdRef.current = checkoutEventId;
+    capture(
+      "starterpack_checkout_started",
+      bundleStarterpackEventProperties({
+        eventId: checkoutEventId,
+        bundle,
+        numsPriceUsd: numsPrice,
+      }),
+    );
+
     const onPurchaseComplete = () => {
+      const purchaseEventId =
+        checkoutEventIdRef.current ??
+        createAnalyticsEventId("starterpack_purchase");
+      capture(
+        "starterpack_purchased",
+        bundleStarterpackEventProperties({
+          eventId: purchaseEventId.replace(
+            "starterpack_checkout",
+            "starterpack_purchase",
+          ),
+          bundle,
+          numsPriceUsd: numsPrice,
+        }),
+      );
+      checkoutEventIdRef.current = null;
       setShowQuestScene(false);
       setShowAchievementScene(false);
       setShowLeaderboardScene(false);
@@ -257,7 +288,7 @@ export const Main = ({ children }: MainProps) => {
       onPurchaseComplete,
       socialClaimOptions: bundle.price === 0n ? socialClaimOptions : undefined,
     });
-  }, [bundle, navigate, chain.id, referralLink]);
+  }, [bundle, navigate, chain, referralLink, capture, numsPrice]);
 
   // Detect new game and navigate to it
   useEffect(() => {
@@ -490,7 +521,18 @@ export const Main = ({ children }: MainProps) => {
             setShowGovernanceScene(false);
             setShowSettingsScene(false);
             setShowAirdropModal(false);
-            capture("purchase_modal_opened", {});
+            if (bundle) {
+              capture(
+                "purchase_modal_opened",
+                bundleStarterpackEventProperties({
+                  eventId: createAnalyticsEventId("purchase_modal_opened"),
+                  bundle,
+                  numsPriceUsd: numsPrice,
+                }),
+              );
+            } else {
+              capture("purchase_modal_opened", {});
+            }
           }}
         >
           {children}

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -83,7 +83,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' https://js.stripe.com https://*.stripe.com https://*.cartridge.gg https://cartridge.gg; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.stripe.com https://*.cartridge.gg https://cartridge.gg wss://* https://*; frame-src 'self' https://*.stripe.com https://*.cartridge.gg https://cartridge.gg;"
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' https://js.stripe.com https://*.stripe.com https://*.cartridge.gg https://cartridge.gg https://analytics.tiktok.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.stripe.com https://*.cartridge.gg https://cartridge.gg wss://* https://*; frame-src 'self' https://*.stripe.com https://*.cartridge.gg https://cartridge.gg;"
         }
       ]
     },
@@ -118,7 +118,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' https://js.stripe.com https://*.stripe.com https://*.cartridge.gg https://cartridge.gg; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.stripe.com https://*.cartridge.gg https://cartridge.gg wss://* https://*; frame-src 'self' https://*.stripe.com https://*.cartridge.gg https://cartridge.gg;"
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' https://js.stripe.com https://*.stripe.com https://*.cartridge.gg https://cartridge.gg https://analytics.tiktok.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.stripe.com https://*.cartridge.gg https://cartridge.gg wss://* https://*; frame-src 'self' https://*.stripe.com https://*.cartridge.gg https://cartridge.gg;"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- persist TikTok/paid-ad attribution from landing URLs and register it on PostHog events
- load the TikTok browser pixel behind `VITE_TIKTOK_PIXEL_ID` and update CSP for the pixel script
- emit canonical Starterpack view, checkout, and purchase PostHog events with stable event IDs and product properties
- add attribution unit tests

## Verification
- `pnpm --filter @cartridge/nums type:check`
- `pnpm --filter @cartridge/nums test`
- `pnpm --filter @cartridge/nums lint:check`
- `pnpm --filter @cartridge/nums format:check`
- `pnpm --filter @cartridge/nums build`
- pre-commit hook also ran root format/lint/typecheck/test/build

## Deployment notes
- set `VITE_TIKTOK_PIXEL_ID` in Vercel
- configure the PostHog TikTok Ads destination with the same Pixel ID and TikTok Events API token
- map NUMS events to TikTok standard events in PostHog: `starterpack_viewed` -> `ViewContent`, `starterpack_checkout_started` -> `InitiateCheckout`, `starterpack_purchased` -> `Purchase`
- use `event.properties.ttclid ?? person.properties.ttclid ?? person.properties.$initial_ttclid` for TikTok click ID mapping
