### PR TITLE
Add Meta Pixel support

### DIFF
--- a/client/src/context/posthog.tsx
+++ b/client/src/context/posthog.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import PostHog from "posthog-js-lite";
 import { resolveAttribution } from "@/lib/attribution";
+import { loadMetaPixel, NUMS_META_PIXEL_ID } from "@/lib/meta-pixel";
 import { loadTikTokPixel, NUMS_TIKTOK_PIXEL_ID } from "@/lib/tiktok-pixel";
 
 type JsonValue =
@@ -49,6 +50,11 @@ export const PostHogProvider = ({ children }: PostHogProviderProps) => {
       import.meta.env.VITE_TIKTOK_PIXEL_ID || NUMS_TIKTOK_PIXEL_ID;
     if (!isLocalhost && pixelId) {
       loadTikTokPixel(pixelId);
+    }
+    const metaPixelId =
+      import.meta.env.VITE_META_PIXEL_ID || NUMS_META_PIXEL_ID;
+    if (!isLocalhost && metaPixelId) {
+      loadMetaPixel(metaPixelId);
     }
 
     const key = import.meta.env.VITE_POSTHOG_KEY;

--- a/client/src/lib/attribution.test.ts
+++ b/client/src/lib/attribution.test.ts
@@ -64,6 +64,23 @@ describe("attribution", () => {
     expect(latest?.setOnceProperties.$initial_utm_campaign).toBe("alpha");
   });
 
+  it("derives Meta fbc from fbclid using the landing timestamp", () => {
+    const attribution = resolveAttribution({
+      location: createLocation("https://nums.gg/?fbclid=meta-click"),
+      referrer: "https://www.facebook.com/",
+      storage: createStorage(),
+      now: Date.UTC(2026, 4, 1),
+    });
+
+    expect(attribution?.eventProperties.fbclid).toBe("meta-click");
+    expect(attribution?.eventProperties.fbc).toBe(
+      `fb.1.${Date.UTC(2026, 4, 1)}.meta-click`,
+    );
+    expect(attribution?.setOnceProperties.$initial_fbc).toBe(
+      `fb.1.${Date.UTC(2026, 4, 1)}.meta-click`,
+    );
+  });
+
   it("reuses unexpired stored attribution when the URL has no ad params", () => {
     const storage = createStorage();
     resolveAttribution({

--- a/client/src/lib/attribution.ts
+++ b/client/src/lib/attribution.ts
@@ -98,6 +98,9 @@ export const buildAttributionSnapshot = (
   now: number,
 ): AttributionSnapshot | null => {
   const fields = parseAttributionFields(location.search);
+  if (fields.fbclid) {
+    fields.fbc = `fb.1.${now}.${fields.fbclid}`;
+  }
   if (Object.keys(fields).length === 0) return null;
 
   return {

--- a/client/src/lib/meta-pixel.ts
+++ b/client/src/lib/meta-pixel.ts
@@ -1,0 +1,61 @@
+type MetaPixelCommand = "init" | "track" | "trackCustom" | "consent";
+
+type MetaPixelQueue = {
+  (...args: unknown[]): void;
+  callMethod?: (...args: unknown[]) => void;
+  queue: unknown[][];
+  loaded: boolean;
+  version: string;
+  push: MetaPixelQueue;
+};
+
+declare global {
+  interface Window {
+    fbq?: MetaPixelQueue;
+    _fbq?: MetaPixelQueue;
+    __numsMetaPixelId?: string;
+  }
+}
+
+const META_SCRIPT_SRC = "https://connect.facebook.net/en_US/fbevents.js";
+export const NUMS_META_PIXEL_ID = "1470539818141286";
+
+const createQueue = (): MetaPixelQueue => {
+  const fbq = ((...args: unknown[]) => {
+    if (fbq.callMethod) {
+      fbq.callMethod(...args);
+      return;
+    }
+    fbq.queue.push(args);
+  }) as MetaPixelQueue;
+
+  fbq.queue = [];
+  fbq.loaded = true;
+  fbq.version = "2.0";
+  fbq.push = fbq;
+  return fbq;
+};
+
+export const loadMetaPixel = (pixelId: string): void => {
+  if (typeof window === "undefined" || !pixelId) return;
+  if (window.__numsMetaPixelId === pixelId) {
+    window.fbq?.("track", "PageView");
+    return;
+  }
+
+  const fbq = (window.fbq = window.fbq || createQueue());
+  window._fbq = window._fbq || fbq;
+
+  if (!document.querySelector(`script[src="${META_SCRIPT_SRC}"]`)) {
+    const script = document.createElement("script");
+    script.async = true;
+    script.src = META_SCRIPT_SRC;
+
+    const firstScript = document.getElementsByTagName("script")[0];
+    firstScript.parentNode?.insertBefore(script, firstScript);
+  }
+
+  fbq("init" satisfies MetaPixelCommand, pixelId);
+  fbq("track" satisfies MetaPixelCommand, "PageView");
+  window.__numsMetaPixelId = pixelId;
+};

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -83,7 +83,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' https://js.stripe.com https://*.stripe.com https://*.cartridge.gg https://cartridge.gg https://analytics.tiktok.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.stripe.com https://*.cartridge.gg https://cartridge.gg wss://* https://*; frame-src 'self' https://*.stripe.com https://*.cartridge.gg https://cartridge.gg;"
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' https://js.stripe.com https://*.stripe.com https://*.cartridge.gg https://cartridge.gg https://analytics.tiktok.com https://connect.facebook.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob: https://www.facebook.com; connect-src 'self' https://*.stripe.com https://*.cartridge.gg https://cartridge.gg wss://* https://*; frame-src 'self' https://*.stripe.com https://*.cartridge.gg https://cartridge.gg;"
         }
       ]
     },
@@ -118,7 +118,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' https://js.stripe.com https://*.stripe.com https://*.cartridge.gg https://cartridge.gg https://analytics.tiktok.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.stripe.com https://*.cartridge.gg https://cartridge.gg wss://* https://*; frame-src 'self' https://*.stripe.com https://*.cartridge.gg https://cartridge.gg;"
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' https://js.stripe.com https://*.stripe.com https://*.cartridge.gg https://cartridge.gg https://analytics.tiktok.com https://connect.facebook.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob: https://www.facebook.com; connect-src 'self' https://*.stripe.com https://*.cartridge.gg https://cartridge.gg wss://* https://*; frame-src 'self' https://*.stripe.com https://*.cartridge.gg https://cartridge.gg;"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add a programmatic Meta Pixel loader behind `VITE_META_PIXEL_ID`
- load Meta PageView alongside the existing TikTok Pixel setup in non-local environments
- derive Meta `fbc` attribution from landing-page `fbclid` for PostHog/Meta CAPI mapping
- allow Meta pixel script host in CSP

## Verification
- `pnpm --filter @cartridge/nums type:check`
- `pnpm --filter @cartridge/nums test -- src/lib/attribution.test.ts src/context/posthog.test.tsx`
- `pnpm --filter @cartridge/nums lint:check`
- `pnpm --filter @cartridge/nums format:check`

## Deployment notes
- set `VITE_META_PIXEL_ID` to the Meta Pixel ID
- configure PostHog Meta/Conversions API destination with the same Pixel ID and access token
- map attribution using `event.properties.fbc ?? person.properties.fbc ?? person.properties.$initial_fbc`
