### PR TITLE
Use shared iOS notification kit

### DIFF
--- a/ios/Nums WebApp/PushNotifications.swift
+++ b/ios/Nums WebApp/PushNotifications.swift
@@ -1,8 +1,7 @@
-import UIKit
-import UserNotifications
+import CartridgeIOSKit
+import Foundation
 import WebKit
 
-private let notificationAppID = "nums"
 private let notificationAPIURL: URL = {
     if let value = Bundle.main.object(forInfoDictionaryKey: "NotificationAPIURL") as? String,
        let url = URL(string: value) {
@@ -10,425 +9,59 @@ private let notificationAPIURL: URL = {
     }
     return URL(string: "https://api.cartridge.gg/query")!
 }()
-private let notificationDeviceIDDefaultsKey = "nums.notificationDeviceID"
 
-private var apnsDeviceToken: String?
-private var notificationRegistrationInFlight = false
-private var notificationRegistrationQueued = false
-private var notificationSessionReadyHandled = false
+private let notificationBridge = CartridgeNotificationBridge(
+    configuration: CartridgeNotificationConfiguration(
+        appID: "nums",
+        apiURL: notificationAPIURL,
+        errorDomain: "NumsNotifications"
+    ),
+    webViewProvider: { currentAppWebView() }
+)
 
-class SubscribeMessage {
-    var topic  = ""
-    var eventValue = ""
-    var unsubscribe = false
-    struct Keys {
-        static var TOPIC = "topic"
-        static var UNSUBSCRIBE = "unsubscribe"
-        static var EVENTVALUE = "eventValue"
-    }
-    convenience init(dict: Dictionary<String,Any>) {
-        self.init()
-        if let topic = dict[Keys.TOPIC] as? String {
-            self.topic = topic
-        }
-        if let unsubscribe = dict[Keys.UNSUBSCRIBE] as? Bool {
-            self.unsubscribe = unsubscribe
-        }
-        if let eventValue = dict[Keys.EVENTVALUE] as? String {
-            self.eventValue = eventValue
-        }
-    }
+func registerNotificationScriptMessageHandlers(
+    on userContentController: WKUserContentController,
+    handler: WKScriptMessageHandler
+) {
+    notificationBridge.registerScriptMessageHandlers(on: userContentController, handler: handler)
+}
+
+func triggerNotificationRegistrationCheck(in webView: WKWebView) {
+    notificationBridge.triggerSessionCheck(in: webView)
 }
 
 func handleSubscribeTouch(message: WKScriptMessage) {
-  // [START subscribe_topic]
-    let subscribeMessages = parseSubscribeMessage(message: message)
-    if (subscribeMessages.count > 0){
-        let _message = subscribeMessages[0]
-        let action = _message.unsubscribe ? "unsubscribe" : "subscribe"
-        print("Push topic \(action) requested for '\(_message.topic)', but Firebase is not configured.")
-    }
-
-
-  // [END subscribe_topic]
-}
-
-func parseSubscribeMessage(message: WKScriptMessage) -> [SubscribeMessage] {
-    var subscribeMessages = [SubscribeMessage]()
-    if let objStr = message.body as? String {
-
-        let data: Data = objStr.data(using: .utf8)!
-        do {
-            let jsObj = try JSONSerialization.jsonObject(with: data, options: .init(rawValue: 0))
-            if let jsonObjDict = jsObj as? Dictionary<String, Any> {
-                let subscribeMessage = SubscribeMessage(dict: jsonObjDict)
-                subscribeMessages.append(subscribeMessage)
-            } else if let jsonArr = jsObj as? [Dictionary<String, Any>] {
-                for jsonObj in jsonArr {
-                    let sMessage = SubscribeMessage(dict: jsonObj)
-                    subscribeMessages.append(sMessage)
-                }
-            }
-        } catch _ {
-
-        }
-    }
-    return subscribeMessages
-}
-
-func returnPermissionResult(isGranted: Bool){
-    DispatchQueue.main.async(execute: {
-        guard let webView = currentAppWebView() else { return }
-        if (isGranted){
-            webView.evaluateJavaScript("this.dispatchEvent(new CustomEvent('push-permission-request', { detail: 'granted' }))")
-        }
-        else {
-            webView.evaluateJavaScript("this.dispatchEvent(new CustomEvent('push-permission-request', { detail: 'denied' }))")
-        }
-    })
-}
-func returnPermissionState(state: String){
-    DispatchQueue.main.async(execute: {
-        currentAppWebView()?.evaluateJavaScript("this.dispatchEvent(new CustomEvent('push-permission-state', { detail: '\(state)' }))")
-    })
+    notificationBridge.handleSubscribe(message: message)
 }
 
 func handlePushPermission() {
-    UNUserNotificationCenter.current().getNotificationSettings () { settings in
-            switch settings.authorizationStatus {
-            case .notDetermined:
-                let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
-                UNUserNotificationCenter.current().requestAuthorization(
-                    options: authOptions,
-                    completionHandler: { (success, error) in
-                        if error == nil {
-                            if success == true {
-                                returnPermissionResult(isGranted: true)
-                                DispatchQueue.main.async {
-                                  UIApplication.shared.registerForRemoteNotifications()
-                                }
-                            }
-                            else {
-                                returnPermissionResult(isGranted: false)
-                            }
-                        }
-                        else {
-                            returnPermissionResult(isGranted: false)
-                        }
-                    }
-                )
-            case .denied:
-                returnPermissionResult(isGranted: false)
-            case .authorized, .ephemeral, .provisional:
-                returnPermissionResult(isGranted: true)
-            @unknown default:
-                return;
-            }
-        }
+    notificationBridge.handlePushPermission()
 }
+
 func handlePushState() {
-    UNUserNotificationCenter.current().getNotificationSettings () { settings in
-        switch settings.authorizationStatus {
-        case .notDetermined:
-            returnPermissionState(state: "notDetermined")
-        case .denied:
-            returnPermissionState(state: "denied")
-        case .authorized:
-            returnPermissionState(state: "authorized")
-        case .ephemeral:
-            returnPermissionState(state: "ephemeral")
-        case .provisional:
-            returnPermissionState(state: "provisional")
-        @unknown default:
-            returnPermissionState(state: "unknown")
-            return;
-        }
-    }
+    notificationBridge.handlePushState()
 }
 
-func checkViewAndEvaluate(event: String, detail: String) {
-    if let webView = currentAppWebView(), !webView.isHidden && !webView.isLoading {
-        DispatchQueue.main.async(execute: {
-            webView.evaluateJavaScript("window.dispatchEvent(new CustomEvent(\(jsonStringLiteral(event)), { detail: \(detail) }))")
-        })
-    }
-    else {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            checkViewAndEvaluate(event: event, detail: detail)
-        }
-    }
-}
-
-func handlePushTokenRequest(){
-    DispatchQueue.main.async(execute: {
-        if let token = apnsDeviceToken {
-            checkViewAndEvaluate(event: "push-token", detail: jsonStringLiteral(token))
-            registerNotificationDeviceIfPossible()
-            return
-        }
-
-        UIApplication.shared.registerForRemoteNotifications()
-        checkViewAndEvaluate(event: "push-token", detail: "null")
-    })
+func handlePushTokenRequest() {
+    notificationBridge.handlePushTokenRequest()
 }
 
 func handleNotificationSessionReady() {
-    print("Notification session ready signal received")
-    if notificationSessionReadyHandled {
-        registerNotificationDeviceIfPossible()
-        return
-    }
-    notificationSessionReadyHandled = true
-
-    UNUserNotificationCenter.current().getNotificationSettings { settings in
-        print("Notification authorization status: \(settings.authorizationStatus.rawValue)")
-        switch settings.authorizationStatus {
-        case .notDetermined:
-            let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
-            UNUserNotificationCenter.current().requestAuthorization(options: authOptions) { granted, error in
-                if let error = error {
-                    print("Notification authorization failed: \(error.localizedDescription)")
-                }
-                guard granted else {
-                    print("Notification authorization was not granted")
-                    return
-                }
-                DispatchQueue.main.async {
-                    UIApplication.shared.registerForRemoteNotifications()
-                }
-            }
-        case .authorized, .ephemeral, .provisional:
-            DispatchQueue.main.async {
-                UIApplication.shared.registerForRemoteNotifications()
-                registerNotificationDeviceIfPossible()
-            }
-        case .denied:
-            print("Notification authorization denied in Settings")
-            return
-        @unknown default:
-            print("Notification authorization status is unknown")
-            return
-        }
-    }
+    notificationBridge.handleNotificationSessionReady()
 }
 
 func setAPNSToken(_ deviceToken: Data) {
-    apnsDeviceToken = deviceToken.map { String(format: "%02x", $0) }.joined()
-    print("APNs token received")
-    registerNotificationDeviceIfPossible()
-
-    if let token = apnsDeviceToken {
-        checkViewAndEvaluate(event: "push-token", detail: jsonStringLiteral(token))
-    }
+    notificationBridge.setAPNSToken(deviceToken)
 }
 
 func disableRegisteredNotificationDevice(completion: (() -> Void)? = nil) {
-    guard let deviceID = UserDefaults.standard.string(forKey: notificationDeviceIDDefaultsKey), !deviceID.isEmpty else {
-        completion?()
-        return
-    }
-
-    performNotificationGraphQLRequest(
-        query: """
-        mutation DisableNotificationDevice($id: ID!) {
-          disableNotificationDevice(id: $id)
-        }
-        """,
-        variables: ["id": deviceID]
-    ) { _, error in
-        if let error = error {
-            print("Failed to disable notification device: \(error.localizedDescription)")
-        }
-        UserDefaults.standard.removeObject(forKey: notificationDeviceIDDefaultsKey)
-        completion?()
-    }
+    notificationBridge.disableRegisteredNotificationDevice(completion: completion)
 }
 
-private func registerNotificationDeviceIfPossible() {
-    guard let token = apnsDeviceToken, !token.isEmpty else {
-        print("Notification registration waiting for APNs token")
-        return
-    }
-    guard isValidAPNSToken(token) else {
-        print("Notification registration skipped: invalid APNs token")
-        return
-    }
-
-    if notificationRegistrationInFlight {
-        notificationRegistrationQueued = true
-        return
-    }
-
-    notificationRegistrationInFlight = true
-    print("Registering notification device with APNs provider")
-    performNotificationGraphQLRequest(
-        query: """
-        mutation RegisterNotificationDevice($input: RegisterNotificationDeviceInput!) {
-          registerNotificationDevice(input: $input) {
-            id
-          }
-        }
-        """,
-        variables: [
-            "input": [
-                "appId": notificationAppID,
-                "platform": "IOS",
-                "provider": "APNS",
-                "token": token,
-            ],
-        ]
-    ) { json, error in
-        notificationRegistrationInFlight = false
-
-        if let error = error {
-            print("Failed to register notification device: \(error.localizedDescription)")
-        } else if let deviceID = notificationDeviceID(from: json) {
-            UserDefaults.standard.set(deviceID, forKey: notificationDeviceIDDefaultsKey)
-            print("Registered notification device: \(deviceID)")
-        }
-
-        if notificationRegistrationQueued {
-            notificationRegistrationQueued = false
-            registerNotificationDeviceIfPossible()
-        }
-    }
+func sendPushToWebView(userInfo: [AnyHashable: Any]) {
+    notificationBridge.sendPushToWebView(userInfo: userInfo)
 }
 
-private func performNotificationGraphQLRequest(
-    query: String,
-    variables: [String: Any],
-    completion: @escaping ([String: Any]?, Error?) -> Void
-) {
-    WKWebsiteDataStore.default().httpCookieStore.getAllCookies { cookies in
-        var request = URLRequest(url: notificationAPIURL)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-
-        let matchingCookies = cookiesForNotificationAPI(cookies)
-        print("Notification API cookies matched: \(matchingCookies.count)")
-        if !matchingCookies.isEmpty,
-           let cookieHeader = HTTPCookie.requestHeaderFields(with: matchingCookies)["Cookie"] {
-            request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
-        }
-
-        do {
-            request.httpBody = try JSONSerialization.data(withJSONObject: [
-                "query": query,
-                "variables": variables,
-            ])
-        } catch {
-            DispatchQueue.main.async { completion(nil, error) }
-            return
-        }
-
-        URLSession.shared.dataTask(with: request) { data, response, error in
-            if let error = error {
-                DispatchQueue.main.async { completion(nil, error) }
-                return
-            }
-
-            if let httpResponse = response as? HTTPURLResponse,
-               !(200..<300).contains(httpResponse.statusCode) {
-                let error = NSError(
-                    domain: "NumsNotifications",
-                    code: httpResponse.statusCode,
-                    userInfo: [NSLocalizedDescriptionKey: "Notification API returned HTTP \(httpResponse.statusCode)"]
-                )
-                DispatchQueue.main.async { completion(nil, error) }
-                return
-            }
-
-            guard let data = data else {
-                let error = NSError(
-                    domain: "NumsNotifications",
-                    code: -1,
-                    userInfo: [NSLocalizedDescriptionKey: "Notification API returned an empty response"]
-                )
-                DispatchQueue.main.async { completion(nil, error) }
-                return
-            }
-
-            do {
-                let decoded = try JSONSerialization.jsonObject(with: data)
-                guard let json = decoded as? [String: Any] else {
-                    throw NSError(
-                        domain: "NumsNotifications",
-                        code: -2,
-                        userInfo: [NSLocalizedDescriptionKey: "Notification API returned an invalid response"]
-                    )
-                }
-
-                if let errors = json["errors"] as? [[String: Any]], !errors.isEmpty {
-                    let message = (errors.first?["message"] as? String) ?? "Notification API request failed"
-                    throw NSError(
-                        domain: "NumsNotifications",
-                        code: -3,
-                        userInfo: [NSLocalizedDescriptionKey: message]
-                    )
-                }
-
-                DispatchQueue.main.async { completion(json, nil) }
-            } catch {
-                DispatchQueue.main.async { completion(nil, error) }
-            }
-        }.resume()
-    }
-}
-
-private func cookiesForNotificationAPI(_ cookies: [HTTPCookie]) -> [HTTPCookie] {
-    guard let host = notificationAPIURL.host?.lowercased() else { return [] }
-    return cookies.filter { cookie in
-        let domain = cookie.domain.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "."))
-        return host == domain || host.hasSuffix(".\(domain)")
-    }
-}
-
-private func notificationDeviceID(from json: [String: Any]?) -> String? {
-    guard
-        let data = json?["data"] as? [String: Any],
-        let device = data["registerNotificationDevice"] as? [String: Any],
-        let id = device["id"] as? String
-    else {
-        return nil
-    }
-    return id
-}
-
-private func isValidAPNSToken(_ token: String) -> Bool {
-    token.range(of: #"^[0-9a-f]{64}$"#, options: .regularExpression) != nil
-}
-
-private func jsonStringLiteral(_ value: String) -> String {
-    guard
-        let data = try? JSONEncoder().encode(value),
-        let string = String(data: data, encoding: .utf8)
-    else {
-        return "null"
-    }
-    return string
-}
-
-func sendPushToWebView(userInfo: [AnyHashable: Any]){
-    var json = "";
-    do {
-        let jsonData = try JSONSerialization.data(withJSONObject: userInfo)
-        json = String(data: jsonData, encoding: .utf8)!
-    } catch {
-        print("ERROR: userInfo parsing problem")
-        return
-    }
-    checkViewAndEvaluate(event: "push-notification", detail: json)
-}
-
-func sendPushClickToWebView(userInfo: [AnyHashable: Any]){
-    var json = "";
-    do {
-        let jsonData = try JSONSerialization.data(withJSONObject: userInfo)
-        json = String(data: jsonData, encoding: .utf8)!
-    } catch {
-        print("ERROR: userInfo parsing problem")
-        return
-    }
-    checkViewAndEvaluate(event: "push-notification-click", detail: json)
+func sendPushClickToWebView(userInfo: [AnyHashable: Any]) {
+    notificationBridge.sendPushClickToWebView(userInfo: userInfo)
 }

--- a/ios/Nums WebApp/WebView.swift
+++ b/ios/Nums WebApp/WebView.swift
@@ -6,102 +6,6 @@ import SafariServices
 let iframeStorageSnapshotKeyPrefix = "__iframeStorageSnapshot__:"
 let iframeStorageTargetHost = "x.cartridge.gg"
 
-func triggerNotificationRegistrationCheck(in webView: WKWebView) {
-    let script = """
-    (function() {
-      var targetHost = "\(iframeStorageTargetHost)";
-      var keyPrefix = "\(iframeStorageSnapshotKeyPrefix)";
-      var hasOwn = function(obj, key) {
-        return Object.prototype.hasOwnProperty.call(obj, key);
-      };
-      var safeJsonParse = function(value) {
-        if (typeof value !== "string" || value.length === 0) return null;
-        try {
-          return JSON.parse(value);
-        } catch (_) {
-          return null;
-        }
-      };
-      var parseSessionExpirySeconds = function(rawSessionValue) {
-        var parsed = safeJsonParse(rawSessionValue);
-        var expiresAt = parsed &&
-          parsed.Session &&
-          parsed.Session.session &&
-          parsed.Session.session.inner &&
-          parsed.Session.session.inner.expires_at;
-        if (typeof expiresAt !== "string" || expiresAt.length === 0) return null;
-        var value = /^0x[0-9a-f]+$/i.test(expiresAt) ? parseInt(expiresAt, 16) : parseInt(expiresAt, 10);
-        return Number.isFinite(value) ? value : null;
-      };
-      var hasValidActiveSession = function(snapshot) {
-        var activeKey = "@cartridge/active";
-        if (!snapshot || typeof snapshot !== "object" || !hasOwn(snapshot, activeKey)) return false;
-
-        var parsedActive = safeJsonParse(snapshot[activeKey]);
-        var activeData = parsedActive && parsedActive.Active ? parsedActive.Active : null;
-        var activeAddress = activeData && typeof activeData.address === "string" ? activeData.address.toLowerCase() : "";
-        var activeChainId = activeData && typeof activeData.chain_id === "string" ? activeData.chain_id.toLowerCase() : "";
-        if (!activeAddress || !activeChainId) return false;
-
-        var accountKey = "@cartridge/account/" + activeAddress + "/" + activeChainId;
-        var sessionKey = "@cartridge/session/" + activeAddress + "/" + activeChainId;
-        if (!hasOwn(snapshot, accountKey) || !hasOwn(snapshot, sessionKey)) return false;
-
-        var expiresAt = parseSessionExpirySeconds(snapshot[sessionKey]);
-        return !(typeof expiresAt === "number" && expiresAt <= Math.floor(Date.now() / 1000));
-      };
-      var isManagedTopStorageKey = function(key) {
-        return typeof key === "string" &&
-          (key.indexOf("@cartridge/") === 0 || key === "needs_session_creation" || key === "last_pending_block_tx");
-      };
-      var readTopStorageSnapshot = function() {
-        var snapshot = {};
-        try {
-          for (var i = 0; i < localStorage.length; i += 1) {
-            var key = localStorage.key(i);
-            if (!isManagedTopStorageKey(key)) continue;
-            var value = localStorage.getItem(key);
-            if (typeof value === "string") {
-              snapshot[key] = value;
-            }
-          }
-        } catch (_) {}
-        return snapshot;
-      };
-      var readStoredSnapshot = function() {
-        try {
-          var raw = localStorage.getItem(keyPrefix + targetHost);
-          var parsed = raw ? JSON.parse(raw) : null;
-          return parsed && typeof parsed === "object" ? parsed : {};
-        } catch (_) {
-          return {};
-        }
-      };
-      var authenticated = hasValidActiveSession(readTopStorageSnapshot()) || hasValidActiveSession(readStoredSnapshot());
-      if (authenticated) {
-        try {
-          var handlers = window.webkit && window.webkit.messageHandlers;
-          var handler = handlers && handlers["notification-session-ready"];
-          if (handler && typeof handler.postMessage === "function") {
-            handler.postMessage({ source: "native-session-check" });
-          }
-        } catch (_) {}
-      }
-      return authenticated;
-    })();
-    """
-
-    webView.evaluateJavaScript(script) { result, error in
-        if let error = error {
-            print("Notification session check failed: \(error.localizedDescription)")
-            return
-        }
-        if let authenticated = result as? Bool {
-            print("Notification session check authenticated: \(authenticated)")
-        }
-    }
-}
-
 func createWebView(container: UIView, WKSMH: WKScriptMessageHandler, WKND: WKNavigationDelegate) -> WKWebView{
 
     let config = WKWebViewConfiguration()
@@ -110,11 +14,7 @@ func createWebView(container: UIView, WKSMH: WKScriptMessageHandler, WKND: WKNav
     config.processPool = WebViewProcessPool.shared
 
     userContentController.add(WKSMH, name: "print")
-    userContentController.add(WKSMH, name: "push-subscribe")
-    userContentController.add(WKSMH, name: "push-permission-request")
-    userContentController.add(WKSMH, name: "push-permission-state")
-    userContentController.add(WKSMH, name: "push-token")
-    userContentController.add(WKSMH, name: "notification-session-ready")
+    registerNotificationScriptMessageHandlers(on: userContentController, handler: WKSMH)
     if enableCartridgeIframeStorageRelay {
         userContentController.add(WKSMH, name: "cartridge-logout-cleanup")
     }

--- a/ios/Nums.xcodeproj/project.pbxproj
+++ b/ios/Nums.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C7A200000000000000000001 /* CartridgeIOSKit in Frameworks */ = {isa = PBXBuildFile; productRef = C7A200000000000000000003 /* CartridgeIOSKit */; };
 		25A54F9B2F5F471B009E93CA /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 25A54F9A2F5F471B009E93CA /* PrivacyInfo.xcprivacy */; };
 		AA0000012F5F471B009E93CA /* countup.svg in Resources */ = {isa = PBXBuildFile; fileRef = AA0000022F5F471B009E93CA /* countup.svg */; };
 		595F23A525CEFBFE0053416C /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595F239A25CEFBFD0053416C /* Settings.swift */; };
@@ -44,6 +45,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C7A200000000000000000001 /* CartridgeIOSKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -87,6 +89,9 @@
 			dependencies = (
 			);
 			name = Nums;
+			packageProductDependencies = (
+				C7A200000000000000000003 /* CartridgeIOSKit */,
+			);
 			productName = Nums;
 			productReference = 59333BAA25CFF706003392A4 /* Nums.app */;
 			productType = "com.apple.product-type.application";
@@ -116,6 +121,9 @@
 				Base,
 			);
 			mainGroup = CD89F880237E9D9200C436A1;
+			packageReferences = (
+				C7A200000000000000000002 /* XCRemoteSwiftPackageReference "cartridge-ios-kit" */,
+			);
 			productRefGroup = CD89F880237E9D9200C436A1;
 			projectDirPath = "";
 			projectRoot = "";
@@ -175,6 +183,25 @@
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		C7A200000000000000000002 /* XCRemoteSwiftPackageReference "cartridge-ios-kit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/cartridge-gg/cartridge-ios-kit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		C7A200000000000000000003 /* CartridgeIOSKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C7A200000000000000000002 /* XCRemoteSwiftPackageReference "cartridge-ios-kit" */;
+			productName = CartridgeIOSKit;
+		};
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCBuildConfiguration section */
 		CD89F89B237E9D9300C436A1 /* Debug */ = {

--- a/ios/Nums.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Nums.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "7959d0ddc23fde2ace81f63c9d2e8c56078c70f620bc33e732619c42ecedc06e",
+  "pins" : [
+    {
+      "identity" : "cartridge-ios-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/cartridge-gg/cartridge-ios-kit",
+      "state" : {
+        "revision" : "002d241b1c936e9a4020f4faa555cc1b33d3aa55",
+        "version" : "0.1.0"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
## What changed
- Added the CartridgeIOSKit Swift package dependency to the Nums iOS app on main.
- Replaced the duplicated notification bridge implementation with a small app-specific wrapper.
- Kept the app id as `nums` and pinned the Swift package resolution to v0.1.0.

## Why
The iOS app also exists on main, so this mirrors the mobile-branch notification-kit integration there too.

## Testing
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project "ios/Nums.xcodeproj" -scheme "Nums" -destination "generic/platform=iOS" CODE_SIGNING_ALLOWED=NO build`
- `git diff --check origin/main...HEAD`