### PR TITLE
Pin Cartridge controller to stable release

### DIFF
--- a/client/src/constants/offline.ts
+++ b/client/src/constants/offline.ts
@@ -1,5 +1,9 @@
 import { Config, Starterpack } from "@/models";
-import { DEFAULT_SLOT_COUNT, DEFAULT_SLOT_MAX, DEFAULT_SLOT_MIN } from "@/constants";
+import {
+  DEFAULT_SLOT_COUNT,
+  DEFAULT_SLOT_MAX,
+  DEFAULT_SLOT_MIN,
+} from "@/constants";
 
 export const OFFLINE_NUMS_PRICE = 0.001;
 export const OFFLINE_NUMS_PRICE_MICRO = 1000n;

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -96,13 +96,7 @@ export const Home = () => {
       gameId,
       setGameId,
     };
-  }, [
-    practiceGames,
-    chartData,
-    chartAbscissa,
-    gameId,
-    setGameId,
-  ]);
+  }, [practiceGames, chartData, chartAbscissa, gameId, setGameId]);
 
   // Set initial gameId to the first active game if available
   useEffect(() => {
@@ -158,7 +152,14 @@ export const Home = () => {
       continueGame(gameId);
       navigate(`/practice/${gameId}`);
     }
-  }, [gameId, practiceGames, continueGame, navigate, isConnected, handleConnect]);
+  }, [
+    gameId,
+    practiceGames,
+    continueGame,
+    navigate,
+    isConnected,
+    handleConnect,
+  ]);
 
   return (
     <HomeScene

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "dependencies": {
     "@bal7hazar/arcade-sdk": "^0.0.74",
-    "@cartridge/connector": "0.13.11-alpha.2",
-    "@cartridge/controller": "0.13.11-alpha.2",
+    "@cartridge/connector": "0.13.11",
+    "@cartridge/controller": "0.13.11",
     "@cartridge/presets": "^0.5.2",
     "@chakra-ui/react": "^3.29.0",
     "@dojoengine/core": "1.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@cartridge/connector':
-      specifier: 0.13.11-alpha.2
-      version: 0.13.11-alpha.2
+      specifier: 0.13.11
+      version: 0.13.11
     '@cartridge/controller':
-      specifier: 0.13.11-alpha.2
-      version: 0.13.11-alpha.2
+      specifier: 0.13.11
+      version: 0.13.11
     '@cartridge/presets':
       specifier: github:cartridge-gg/presets#07cb073
       version: 0.0.1
@@ -45,11 +45,11 @@ importers:
         specifier: ^0.0.74
         version: 0.0.74(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(get-starknet-core@3.3.5(starknet@8.9.2))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.1))(zod@3.25.76)
       '@cartridge/connector':
-        specifier: 0.13.11-alpha.2
-        version: 0.13.11-alpha.2(@starknet-react/core@5.0.3(get-starknet-core@3.3.5(starknet@8.9.2))(react@19.2.1)(starknet@8.9.2)(typescript@5.9.3))(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(zod@3.25.76)
+        specifier: 0.13.11
+        version: 0.13.11(@starknet-react/core@5.0.3(get-starknet-core@3.3.5(starknet@8.9.2))(react@19.2.1)(starknet@8.9.2)(typescript@5.9.3))(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(zod@3.25.76)
       '@cartridge/controller':
-        specifier: 0.13.11-alpha.2
-        version: 0.13.11-alpha.2(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(zod@3.25.76)
+        specifier: 0.13.11
+        version: 0.13.11(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(zod@3.25.76)
       '@cartridge/presets':
         specifier: ^0.5.2
         version: 0.5.2
@@ -215,10 +215,10 @@ importers:
     dependencies:
       '@cartridge/connector':
         specifier: 'catalog:'
-        version: 0.13.11-alpha.2(@starknet-react/core@5.0.3(get-starknet-core@3.3.5(starknet@8.9.2))(react@19.2.1)(starknet@8.9.2)(typescript@5.9.3))(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(zod@3.25.76)
+        version: 0.13.11(@starknet-react/core@5.0.3(get-starknet-core@3.3.5(starknet@8.9.2))(react@19.2.1)(starknet@8.9.2)(typescript@5.9.3))(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(zod@3.25.76)
       '@cartridge/controller':
         specifier: 'catalog:'
-        version: 0.13.11-alpha.2(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(zod@3.25.76)
+        version: 0.13.11(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(zod@3.25.76)
       '@cartridge/presets':
         specifier: 'catalog:'
         version: https://codeload.github.com/cartridge-gg/presets/tar.gz/07cb073
@@ -1312,16 +1312,16 @@ packages:
   '@bytecodealliance/preview2-shim@0.17.6':
     resolution: {integrity: sha512-n3cM88gTen5980UOBAD6xDcNNL3ocTK8keab21bpx1ONdA+ARj7uD1qoFxOWCyKlkpSi195FH+GeAut7Oc6zZw==}
 
-  '@cartridge/connector@0.13.11-alpha.2':
-    resolution: {integrity: sha512-RL0/y+bkbYFZ1oPMYzsVDp5Yt3K2eEC8otv//EbDxQ2YYulmMRz1vzM1L/VktBjci4rJAurxmfKikZ03KvV0Xw==}
+  '@cartridge/connector@0.13.11':
+    resolution: {integrity: sha512-Ad1iXuB6+ln3lltqTcfAQs12iloAcDdlRm7FwGs4Y7cVtlVRTYODXtETmH2InSVpFTkAIx4JJzBZnSWzd/9imw==}
     peerDependencies:
       '@starknet-react/core': ^5.0.1
 
   '@cartridge/controller-wasm@0.10.0':
     resolution: {integrity: sha512-msmQFjZRRAcAbcGf0mt4z4bTvUY6H3ypgYz+imJp+S36SCabvh42vog7FttuvcVKQoVjS5hNKb3rf0YwU/plig==}
 
-  '@cartridge/controller@0.13.11-alpha.2':
-    resolution: {integrity: sha512-UqfmWjjHdb8GeEr2Y7GI0d1RWXFkVGSRtwAFaiwpSqm9dD9HMr58CFMBfh7p9VeKItIcOGCDSqL4fBxwJ0Sqpw==}
+  '@cartridge/controller@0.13.11':
+    resolution: {integrity: sha512-duljBCSATe0qWCWWJim7e5lOb/x71wGW6wd7k3MxRxHwdUn7zlI5Eqt8Vqhs5j+HQ+nUS7MauboyH1RumF/uaw==}
 
   '@cartridge/penpal@6.2.4':
     resolution: {integrity: sha512-tdpOnSJJBFMlgLZ1+z9Ho5e6cG5EgMAb1Cmmh1lGT2tmplogU/XPMjLE6CwvKAPDoe6a38iMnbH+ySTAWWIOKA==}
@@ -13035,9 +13035,9 @@ snapshots:
 
   '@bytecodealliance/preview2-shim@0.17.6': {}
 
-  '@cartridge/connector@0.13.11-alpha.2(@starknet-react/core@5.0.3(get-starknet-core@3.3.5(starknet@8.9.2))(react@19.2.1)(starknet@8.9.2)(typescript@5.9.3))(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(zod@3.25.76)':
+  '@cartridge/connector@0.13.11(@starknet-react/core@5.0.3(get-starknet-core@3.3.5(starknet@8.9.2))(react@19.2.1)(starknet@8.9.2)(typescript@5.9.3))(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(zod@3.25.76)':
     dependencies:
-      '@cartridge/controller': 0.13.11-alpha.2(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(zod@3.25.76)
+      '@cartridge/controller': 0.13.11(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(zod@3.25.76)
       '@starknet-react/core': 5.0.3(get-starknet-core@3.3.5(starknet@8.9.2))(react@19.2.1)(starknet@8.9.2)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -13069,7 +13069,7 @@ snapshots:
 
   '@cartridge/controller-wasm@0.10.0': {}
 
-  '@cartridge/controller@0.13.11-alpha.2(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(zod@3.25.76)':
+  '@cartridge/controller@0.13.11(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(zod@3.25.76)':
     dependencies:
       '@cartridge/controller-wasm': 0.10.0
       '@cartridge/penpal': 6.2.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,8 +3,8 @@ packages:
   - "contracts/tokens"
   - "remotion"
 catalog:
-  "@cartridge/connector": "0.13.11-alpha.2"
-  "@cartridge/controller": "0.13.11-alpha.2"
+  "@cartridge/connector": "0.13.11"
+  "@cartridge/controller": "0.13.11"
   "@cartridge/presets": "github:cartridge-gg/presets#07cb073"
   "@cartridge/ui": "github:cartridge-gg/ui#a823aea"
   "@dojoengine/core": "1.8.8"


### PR DESCRIPTION
## What changed
- Pinned `@cartridge/connector` and `@cartridge/controller` to `0.13.11` in root dependencies and the pnpm catalog.
- Updated the pnpm lockfile to use the stable controller packages.

## Why
The iOS app uses WebView storage persistence, and the controller iframe was staying open after login on the alpha controller build. Dope Wars is already using `0.13.11` with the working login flow, so this aligns Nums with that stable release.

## Testing
- `CI=true pnpm install --frozen-lockfile`
- `pnpm -C client build:check`

Note: `pnpm install --lockfile-only` hit an existing `@cartridge/ui@0.7.14-alpha.2` git dependency resolution issue for `cartridge-gg/presets#90a5fe0`, so the lockfile controller entries were updated directly and then verified with a frozen install.