### PR TITLE
Reconnect after native auth changes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import { mainnet } from "@starknet-react/chains";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Provider as JotaiProvider } from "jotai";
 import { Route, BrowserRouter as Router, Routes } from "react-router-dom";
+import { NativeAuthBridge } from "@/components/containers/native-auth-bridge";
 import { NativeNotificationBridge } from "@/components/containers/native-notification-bridge";
 import { NotificationEvents } from "@/components/containers/notification-events";
 import { DEFAULT_CHAIN_ID, RPC_URL, TORII_URL } from "@/config";
@@ -56,6 +57,7 @@ function App() {
             explorer={voyager}
             provider={provider}
           >
+            <NativeAuthBridge />
             <NativeNotificationBridge />
             <ThemeProvider>
               <AudioProvider>

--- a/client/src/components/containers/native-auth-bridge.tsx
+++ b/client/src/components/containers/native-auth-bridge.tsx
@@ -1,0 +1,43 @@
+import type ControllerConnector from "@cartridge/connector/controller";
+import { useAccount, useConnect } from "@starknet-react/core";
+import { useEffect, useRef } from "react";
+
+const AUTH_CHANGED_EVENT = "cartridge:auth-changed";
+
+type AuthChangedDetail = {
+  authenticated?: boolean;
+  source?: string;
+};
+
+export function NativeAuthBridge() {
+  const { isConnected } = useAccount();
+  const { connectAsync, connectors } = useConnect();
+  const isConnectingRef = useRef(false);
+
+  useEffect(() => {
+    const handleAuthChanged = (event: Event) => {
+      const detail = (event as CustomEvent<AuthChangedDetail>).detail;
+      if (detail?.authenticated !== true) return;
+      if (isConnected || isConnectingRef.current) return;
+
+      const connector = connectors[0];
+      if (!connector) return;
+
+      isConnectingRef.current = true;
+      connectAsync({ connector })
+        .then(() => {
+          (connector as unknown as ControllerConnector).controller?.close?.();
+        })
+        .finally(() => {
+          isConnectingRef.current = false;
+        });
+    };
+
+    window.addEventListener(AUTH_CHANGED_EVENT, handleAuthChanged);
+    return () => {
+      window.removeEventListener(AUTH_CHANGED_EVENT, handleAuthChanged);
+    };
+  }, [connectAsync, connectors, isConnected]);
+
+  return null;
+}

--- a/ios/Nums WebApp/Settings.swift
+++ b/ios/Nums WebApp/Settings.swift
@@ -29,7 +29,7 @@ let statusBarTheme = "dark"    // dark / light, related to override option.
 let pullToRefresh = true    // Enable/disable pull down to refresh page
 let webViewBackgroundColor = UIColor(red: 73/255, green: 25/255, blue: 208/255, alpha: 1)
 let enableCartridgeIframeStorageRelay = true
-let dispatchCartridgeAuthChangedEvent = false
+let dispatchCartridgeAuthChangedEvent = true
 let iframeStorageDebugEnabled = false
 let opensExternalLinksInSafariView = false
 


### PR DESCRIPTION
## What changed
- Added a native auth bridge that listens for the WebView storage relay `cartridge:auth-changed` event.
- Enabled the native auth-changed event dispatch in the iOS app settings.
- When native reports an authenticated Cartridge session, the app re-runs the existing connector connection and closes the controller iframe.

## Why
On iOS, the iframe storage relay can persist the Cartridge session without React seeing a connector state transition. That leaves the controller iframe open and the app still logged out.

## Testing
- `pnpm run format:check`
- `pnpm --dir client build:check`