### PR TITLE
Support controller auth popups in iOS WebView

### DIFF
--- a/ios/Nums WebApp/ViewController.swift
+++ b/ios/Nums WebApp/ViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WebKit
+import CartridgeIOSKit
 
 var appWebView: WKWebView! = nil
 
@@ -16,6 +17,7 @@ class ViewController: UIViewController, WKNavigationDelegate, UIDocumentInteract
     @IBOutlet weak var connectionProblemView: UIImageView!
     @IBOutlet weak var webviewView: UIView!
     var toolbarView: UIToolbar!
+    lazy var popupWebViewCoordinator = CartridgePopupWebViewCoordinator(containerView: webviewView)
 
     var htmlIsLoaded = false;
 

--- a/ios/Nums WebApp/WebView.swift
+++ b/ios/Nums WebApp/WebView.swift
@@ -2,6 +2,7 @@ import UIKit
 import WebKit
 import AuthenticationServices
 import SafariServices
+import CartridgeIOSKit
 
 let iframeStorageSnapshotKeyPrefix = "__iframeStorageSnapshot__:"
 let iframeStorageTargetHost = "x.cartridge.gg"
@@ -1108,13 +1109,22 @@ private func hostMatchesAllowedOrigin(_ requestHost: String, origin: String) -> 
 }
 
 extension ViewController: WKUIDelegate, WKDownloadDelegate {
-    // redirect new tabs to main webview
+    // Keep window.open() navigations in a real popup WebView so controller
+    // auth can postMessage back to its opener and close itself.
     func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
-        if (navigationAction.targetFrame == nil) {
-            webView.load(navigationAction.request)
-        }
-        return nil
+        popupWebViewCoordinator.createPopupWebView(
+            with: configuration,
+            for: navigationAction,
+            sourceWebView: webView,
+            navigationDelegate: self,
+            uiDelegate: self
+        )
     }
+
+    func webViewDidClose(_ webView: WKWebView) {
+        popupWebViewCoordinator.closePopupWebView(webView)
+    }
+
     // restrict navigation to target host, open external links in 3rd party apps
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         if (navigationAction.request.url?.scheme == "about") {

--- a/ios/Nums.xcodeproj/project.pbxproj
+++ b/ios/Nums.xcodeproj/project.pbxproj
@@ -190,7 +190,7 @@
 			repositoryURL = "https://github.com/cartridge-gg/cartridge-ios-kit";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.0;
+				minimumVersion = 0.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/Nums.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Nums.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/cartridge-gg/cartridge-ios-kit",
       "state" : {
-        "revision" : "002d241b1c936e9a4020f4faa555cc1b33d3aa55",
-        "version" : "0.1.0"
+        "revision" : "09b3bd27a592b19f27b64279640aecbe0cf03712",
+        "version" : "0.2.0"
       }
     }
   ],


### PR DESCRIPTION
What changed
- Use the shared CartridgePopupWebViewCoordinator from cartridge-ios-kit for target-blank/window.open navigations.
- Point the Swift package dependency at the cartridge-ios-kit shared WebView helper branch while the kit PR is pending.

Why it changed
- Controller auth now uses a top-level popup for iframe signin/signup. Loading that URL into the main WebView loses the opener relationship, so the popup cannot postMessage back and close correctly.

How it was tested
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project ios/Nums.xcodeproj -scheme Nums -sdk iphonesimulator -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build